### PR TITLE
ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/skillkit/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: docs/skillkit
+        run: npm install
+
+      - name: Build
+        working-directory: docs/skillkit
+        run: npm run build
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/skillkit/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Adds automated deployment workflow for docs/skillkit to GitHub Pages
- Triggers on push to main when docs/skillkit/** files change
- Includes manual workflow_dispatch trigger for on-demand deployments
- Uses GEMINI_API_KEY secret for the AI Skill Generator feature

## Required Setup
1. Enable GitHub Pages in repository settings:
   - Go to Settings → Pages
   - Set Source to "GitHub Actions"
2. Add repository secret:
   - Go to Settings → Secrets and variables → Actions
   - Add `GEMINI_API_KEY` secret (for Skill Generator AI feature)

## Test Plan
- [ ] Enable GitHub Pages in repository settings
- [ ] Add GEMINI_API_KEY secret
- [ ] Trigger workflow manually or push docs changes
- [ ] Verify site is deployed to GitHub Pages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated documentation deployment to GitHub Pages; publishes updates automatically on main branch changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->