### PR TITLE
fix(tui): fix rendering overlap and terminal crash on quit

### DIFF
--- a/apps/skillkit/package.json
+++ b/apps/skillkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillkit",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Supercharge AI coding agents with portable skills. Install, translate, and share skills across Claude Code, Cursor, Codex, Copilot & 13 more",
   "type": "module",
   "bin": {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/agents",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Agent adapters for SkillKit - supports 17+ AI coding agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/cli",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "CLI commands for SkillKit",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/core",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Core functionality for SkillKit - skill discovery, parsing, and translation",
   "type": "module",
   "main": "./dist/index.js",
@@ -45,7 +45,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@types/minimatch": "^6.0.0",
     "minimatch": "^10.1.1",
     "yaml": "^2.6.1",
     "zod": "^3.24.1"

--- a/packages/tui/src/components/SkillList.tsx
+++ b/packages/tui/src/components/SkillList.tsx
@@ -45,25 +45,16 @@ export function SkillList({
         const pointer = isSelected ? symbols.pointer : symbols.pointerInactive;
         const fg = isSelected ? terminalColors.accent : terminalColors.text;
         const statusIcon = skill.enabled ? symbols.active : symbols.pending;
-        const statusColor = skill.enabled
-          ? terminalColors.success
-          : terminalColors.textMuted;
+        const descPart = skill.description
+          ? ` - ${skill.description.slice(0, 40)}${skill.description.length > 40 ? '...' : ''}`
+          : '';
+        // Use single text element to avoid rendering overlap
+        const line = `${pointer} ${skill.name} ${statusIcon}${descPart}`;
 
         return (
-          <box key={skill.name} flexDirection="row">
-            <text fg={fg}>
-              {isSelected ? <b>{pointer} {skill.name}</b> : <>{pointer} {skill.name}</>}
-            </text>
-            <text fg={terminalColors.textMuted}>
-              {' '}{statusIcon}
-            </text>
-            {skill.description && (
-              <text fg={terminalColors.textMuted}>
-                {' '}- {skill.description.slice(0, 40)}
-                {skill.description.length > 40 ? '...' : ''}
-              </text>
-            )}
-          </box>
+          <text key={skill.name} fg={fg}>
+            {isSelected ? <b>{line}</b> : line}
+          </text>
         );
       })}
 

--- a/packages/tui/src/screens/Browse.tsx
+++ b/packages/tui/src/screens/Browse.tsx
@@ -142,19 +142,16 @@ export function Browse({ onNavigate, cols = 80, rows = 24 }: BrowseProps) {
                 const selected = actualIdx === selectedIndex;
                 const indicator = selected ? '▸' : ' ';
                 // Truncate source if needed - clamp to avoid negative slicing
-                const available = Math.max(0, contentWidth - repo.name.length - 6);
-                const safeSlice = Math.max(0, available - 3);
-                const displaySource = available > 0 && repo.source.length > available
-                  ? repo.source.slice(0, safeSlice) + '...'
+                const maxSourceLen = Math.max(0, contentWidth - repo.name.length - 6);
+                const displaySource = maxSourceLen > 3 && repo.source.length > maxSourceLen
+                  ? repo.source.slice(0, maxSourceLen - 3) + '...'
                   : repo.source;
+                // Use single text element to avoid rendering overlap issues
+                const line = `${indicator}${repo.name} · ${displaySource}`;
                 return (
-                  <box key={repo.source} flexDirection="row">
-                    <text fg={terminalColors.text}>{indicator}</text>
-                    <text fg={selected ? terminalColors.accent : terminalColors.text}>
-                      {repo.name}
-                    </text>
-                    <text fg={terminalColors.textMuted}> · {displaySource}</text>
-                  </box>
+                  <text key={repo.source} fg={selected ? terminalColors.accent : terminalColors.text}>
+                    {line}
+                  </text>
                 );
               })}
             </box>

--- a/packages/tui/src/screens/Installed.tsx
+++ b/packages/tui/src/screens/Installed.tsx
@@ -188,15 +188,12 @@ export function Installed({ onNavigate, cols = 80, rows = 24 }: InstalledProps) 
                 const selected = actualIdx === selectedIndex;
                 const indicator = selected ? '▸' : ' ';
                 const statusIcon = skill.enabled !== false ? '●' : '○';
-                const statusColor = skill.enabled !== false ? terminalColors.success : terminalColors.textMuted;
+                // Use single text element to avoid rendering overlap
+                const line = `${indicator}${statusIcon} ${skill.name}`;
                 return (
-                  <box key={skill.name} flexDirection="row">
-                    <text fg={terminalColors.text}>{indicator}</text>
-                    <text fg={statusColor}>{statusIcon} </text>
-                    <text fg={selected ? terminalColors.accent : terminalColors.text}>
-                      {skill.name}
-                    </text>
-                  </box>
+                  <text key={skill.name} fg={selected ? terminalColors.accent : terminalColors.text}>
+                    {line}
+                  </text>
                 );
               })}
 

--- a/packages/tui/src/screens/Marketplace.tsx
+++ b/packages/tui/src/screens/Marketplace.tsx
@@ -109,23 +109,18 @@ export function Marketplace({ onNavigate, cols = 80, rows = 24 }: MarketplacePro
       {/* Featured section */}
       {animPhase >= 3 && (
         <box flexDirection="column">
-          <box flexDirection="row">
-            <text fg={terminalColors.text}>Featured</text>
-            <text fg={terminalColors.textMuted}> · trending</text>
-          </box>
+          <text fg={terminalColors.text}>Featured · <text fg={terminalColors.textMuted}>trending</text></text>
           <text> </text>
 
           {visibleFeatured.map((item, idx) => {
             const selected = idx === selectedIndex;
             const indicator = selected ? '▸' : ' ';
+            // Use single text element to avoid rendering overlap
+            const line = `${indicator}${item.name} ★${item.stars}`;
             return (
-              <box key={item.source} flexDirection="row">
-                <text fg={terminalColors.text}>{indicator}</text>
-                <text fg={selected ? terminalColors.accent : terminalColors.text}>
-                  {item.name}
-                </text>
-                <text fg={terminalColors.recommend}> ★{item.stars}</text>
-              </box>
+              <text key={item.source} fg={selected ? terminalColors.accent : terminalColors.text}>
+                {line}
+              </text>
             );
           })}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
 
   packages/core:
     dependencies:
-      '@types/minimatch':
-        specifier: ^6.0.0
-        version: 6.0.0
       minimatch:
         specifier: ^10.1.1
         version: 10.1.1
@@ -814,10 +811,6 @@ packages:
 
   '@types/http-cache-semantics@4.0.4':
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
-
-  '@types/minimatch@6.0.0':
-    resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
-    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
 
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
@@ -2347,10 +2340,6 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/http-cache-semantics@4.0.4': {}
-
-  '@types/minimatch@6.0.0':
-    dependencies:
-      minimatch: 10.1.1
 
   '@types/node@16.9.1': {}
 


### PR DESCRIPTION
## Summary
- Remove deprecated `@types/minimatch` dependency (minimatch 10.x has bundled types)
- Fix TUI text rendering overlap by using single text elements instead of multiple text elements in box rows
- Fix terminal crash on 'q' press by properly unmounting React tree and restoring terminal state

## Changes
- **packages/core/package.json**: Remove `@types/minimatch` dependency
- **packages/tui/src/index.tsx**: Improved exit handling with proper React unmount and terminal restoration
- **packages/tui/src/screens/Browse.tsx**: Fix text overlap in repository list
- **packages/tui/src/screens/Installed.tsx**: Fix text overlap in skills list
- **packages/tui/src/screens/Marketplace.tsx**: Fix text overlap in featured section
- **packages/tui/src/components/SkillList.tsx**: Fix text overlap in skill list component
- **Version bump**: 1.7.5 → 1.7.6

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 692 tests pass (`pnpm test`)
- [x] Manual test: Run `skillkit ui` and verify no text overlapping
- [x] Manual test: Press 'q' to quit and verify clean terminal exit
- [x] Verify `npm install -g skillkit@1.7.6` has no deprecation warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering overlap issues in TUI skill list and marketplace displays.
  * Improved application shutdown handling with proper cleanup and signal handling.

* **Chores**
  * Bumped version to 1.7.6 across all packages.
  * Removed unused dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->