### PR TITLE
feat(website): add dynamic stats from npm and GitHub APIs

### DIFF
--- a/docs/skillkit/App.tsx
+++ b/docs/skillkit/App.tsx
@@ -105,7 +105,7 @@ export default function App(): React.ReactElement {
       </nav>
 
       <main className="pt-14">
-        <Hero />
+        <Hero version={stats.version} />
 
         <div className="border-b border-zinc-800/50 py-2.5" style={{ background: 'linear-gradient(to bottom, rgba(9,9,11,0.95), rgba(0,0,0,1))' }}>
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">

--- a/docs/skillkit/components/Hero.tsx
+++ b/docs/skillkit/components/Hero.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from './Button';
-import { useStats } from '../hooks/useStats';
+
+interface HeroProps {
+  version: string;
+}
 
 const ASCII_LOGO = `
 ███████╗██╗  ██╗██╗██╗     ██╗     ██╗  ██╗██╗████████╗
@@ -56,12 +59,11 @@ const COPY_ICON = (
   </svg>
 );
 
-export function Hero(): React.ReactElement {
+export function Hero({ version }: HeroProps): React.ReactElement {
   const [copied, setCopied] = useState(false);
   const [visibleLines, setVisibleLines] = useState(0);
   const [typingIndex, setTypingIndex] = useState(0);
   const [currentText, setCurrentText] = useState('');
-  const stats = useStats();
 
   useEffect(() => {
     if (visibleLines >= TERMINAL_LINES.length) {
@@ -128,7 +130,7 @@ export function Hero(): React.ReactElement {
           <div className="animate-fade-in">
             <div className="inline-flex items-center space-x-2 border border-zinc-800 bg-zinc-900/50 px-2 py-0.5 mb-3 backdrop-blur-sm">
               <span className="flex h-1.5 w-1.5 bg-white rounded-full"></span>
-              <span className="text-xs font-mono text-zinc-400">v{stats.version}</span>
+              <span className="text-xs font-mono text-zinc-400">v{version}</span>
             </div>
 
             <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-white mb-3 font-mono">

--- a/docs/skillkit/hooks/useStats.ts
+++ b/docs/skillkit/hooks/useStats.ts
@@ -80,14 +80,14 @@ export function useStats(): Stats {
 
         if (npmResponse.status === 'fulfilled' && npmResponse.value.ok) {
           const npmData = await npmResponse.value.json();
-          if (npmData.downloads) {
+          if (typeof npmData.downloads === 'number' && Number.isFinite(npmData.downloads)) {
             downloads = formatDownloads(npmData.downloads);
           }
         }
 
         if (githubResponse.status === 'fulfilled' && githubResponse.value.ok) {
           const githubData = await githubResponse.value.json();
-          if (githubData.stargazers_count) {
+          if (typeof githubData.stargazers_count === 'number' && Number.isFinite(githubData.stargazers_count)) {
             stars = githubData.stargazers_count;
           }
         }


### PR DESCRIPTION
## Summary
- Create `useStats` hook to fetch real-time version, downloads, and stars from npm and GitHub APIs
- Replace hardcoded values in App.tsx stats bar with dynamic data
- Replace hardcoded version in Hero.tsx badge with dynamic data
- Add 5-minute localStorage cache to reduce API calls
- Graceful fallback to default values if APIs fail

## Changes
- **New**: `docs/skillkit/hooks/useStats.ts` - Custom React hook for fetching stats
- **Modified**: `docs/skillkit/App.tsx` - Use dynamic stats in stats bar
- **Modified**: `docs/skillkit/components/Hero.tsx` - Use dynamic version in badge

## Test plan
- [ ] Verify version displays correctly from npm registry
- [ ] Verify downloads count displays correctly from npm API
- [ ] Verify stars count displays correctly from GitHub API
- [ ] Verify caching works (subsequent loads should be faster)
- [ ] Verify fallback works if APIs fail
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Version, download count, and star metrics are now dynamically fetched and displayed in real-time with local caching for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->