### PR TITLE
feat: add Product Hunt badge to website

### DIFF
--- a/docs/skillkit/App.tsx
+++ b/docs/skillkit/App.tsx
@@ -171,6 +171,18 @@ export default function App(): React.ReactElement {
               </a>
               <span className="text-zinc-800 hidden sm:inline">·</span>
               <a
+                href="https://www.producthunt.com/products/skillkit-2?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-skillkit-2"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hidden sm:flex items-center gap-1.5 text-zinc-500 hover:text-white transition-colors group"
+              >
+                <svg className="w-3 h-3 text-[#da552f] group-hover:text-[#ff6154]" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M13.604 8.4h-3.405V12h3.405a1.8 1.8 0 0 0 0-3.6zM12 0C5.372 0 0 5.372 0 12s5.372 12 12 12 12-5.372 12-12S18.628 0 12 0zm1.604 14.4h-3.405V18H7.801V6h5.804a4.2 4.2 0 0 1 0 8.4z"/>
+                </svg>
+                <span className="text-zinc-400 group-hover:text-white font-medium">Featured</span>
+              </a>
+              <span className="text-zinc-800 hidden sm:inline">·</span>
+              <a
                 href="https://github.com/rohitg00/skillkit/blob/main/LICENSE"
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- Added Product Hunt "Featured" badge to the stats bar (version · downloads · stars · **PH Featured** · license)
- Uses the PH cat icon in brand orange, with "Featured" text
- Only shows on sm+ screens to keep mobile clean
- Blends with existing monochrome style - orange icon is the only color accent

## Test plan
- [ ] Verify PH badge appears in stats bar on desktop
- [ ] Verify it links to the correct Product Hunt page
- [ ] Verify it's hidden on mobile
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
