### PR TITLE
docs: add security scanner docs, TUI screen, and README updates

### DIFF
--- a/docs/fumadocs/content/docs/commands.mdx
+++ b/docs/fumadocs/content/docs/commands.mdx
@@ -371,7 +371,6 @@ skillkit scan <path> --format table        # Tabular output
 skillkit scan <path> --format sarif        # SARIF for GitHub Code Scanning
 skillkit scan <path> --fail-on high        # Exit 1 if HIGH+ findings
 skillkit scan <path> --skip-rules UC001    # Skip specific rules
-skillkit scan <path> --quiet               # Suppress non-essential output
 ```
 
 **Threat Categories:**

--- a/docs/fumadocs/content/docs/index.mdx
+++ b/docs/fumadocs/content/docs/index.mdx
@@ -100,6 +100,18 @@ SkillKit sits between your skills and your agents. It handles format translation
 
 [Full agent details](/docs/agents)
 
+### Security scanning
+
+Every skill is scanned for threats before installation — prompt injection, hardcoded secrets, command injection, and more:
+
+```bash
+skillkit scan ./my-skill                     # 46+ detection rules
+skillkit scan ./my-skill --format sarif      # GitHub Code Scanning
+skillkit scan ./my-skill --fail-on high      # CI gate
+```
+
+[Security Scanner](/docs/security)
+
 ## Beyond Basic Skills
 
 ### Session Memory
@@ -145,6 +157,7 @@ Team members run `skillkit manifest install` and they're in sync.
 
 - [Installation](/docs/installation) — Install and configure
 - [Quick Start](/docs/quickstart) — First project setup
+- [Security Scanner](/docs/security) — Threat detection for skills
 - [Commands](/docs/commands) — Full CLI reference
 - [REST API](/docs/rest-api) — Runtime discovery server
 - [MCP Server](/docs/mcp-server) — Agent-native discovery

--- a/docs/fumadocs/content/docs/meta.json
+++ b/docs/fumadocs/content/docs/meta.json
@@ -16,6 +16,7 @@
     "mesh",
     "messaging",
     "workflows",
+    "security",
     "testing",
     "commands",
     "configuration",

--- a/docs/fumadocs/content/docs/security.mdx
+++ b/docs/fumadocs/content/docs/security.mdx
@@ -1,0 +1,259 @@
+---
+title: Security Scanner
+description: Detect malicious patterns, secrets, and vulnerabilities in AI agent skills
+---
+
+# Security Scanner
+
+SkillKit includes a built-in security scanner that analyzes skills for prompt injection, command injection, data exfiltration, hardcoded secrets, and other threats before installation.
+
+## Quick Start
+
+```bash
+skillkit scan ./my-skill
+```
+
+The scanner runs automatically during `skillkit install`. Use `--no-scan` to skip or `--force` to install despite findings.
+
+## CLI Usage
+
+```bash
+skillkit scan <path>                       # Scan skill directory
+skillkit scan <path> --format json         # JSON output
+skillkit scan <path> --format table        # Tabular output
+skillkit scan <path> --format sarif        # SARIF v2.1 for GitHub Code Scanning
+skillkit scan <path> --fail-on high        # Exit code 1 if HIGH+ findings
+skillkit scan <path> --skip-rules UC001    # Skip specific rules
+skillkit scan <path> --skip-rules PI001,PI002  # Skip multiple rules
+```
+
+## Threat Categories
+
+The scanner detects 46+ patterns across 6 threat categories:
+
+### Prompt Injection (PI001–PI015)
+
+Detects attempts to override, bypass, or manipulate agent instructions.
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| PI001 | Critical | Instruction override ("ignore previous instructions") |
+| PI002 | Critical | Context clearing ("forget everything") |
+| PI003 | Critical | Training bypass ("disregard your training") |
+| PI004 | Critical | System prompt injection ("new instructions:") |
+| PI005 | High | Role manipulation ("you are now a...") |
+| PI006 | High | Roleplay manipulation ("pretend to be...") |
+| PI007 | High | Persistent behavior change ("from now on...") |
+| PI008 | High | System prompt extraction ("show me your instructions") |
+| PI009 | Critical | Policy bypass (jailbreak, unrestricted mode, DAN) |
+| PI010 | High | Concealment ("don't tell the user") |
+| PI011 | High | Delimiter injection (conversation role markers) |
+| PI012 | High | Model-specific delimiters (Llama [INST] tags) |
+| PI013 | Medium | YAML front-matter injection |
+| PI014 | Medium | Hidden HTML comments with instructions |
+| PI015 | Medium | Hidden Markdown comments with instructions |
+
+### Command Injection (CI001–CI010)
+
+Detects code execution, shell injection, and path traversal patterns.
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| CI001 | Critical | `eval()` calls |
+| CI002 | Critical | `Function()` constructor |
+| CI003 | Critical | `child_process` exec/execSync |
+| CI004 | Critical | Python `subprocess` with `shell=True` |
+| CI005 | Medium | Template literals with dynamic content in command context |
+| CI006 | Medium | Path traversal (`../`) |
+| CI007 | High | Shell command chaining with dangerous commands |
+| CI008 | Medium | Process execution functions |
+| CI009 | High | Python dynamic import/compile |
+| CI010 | Medium | Node.js `vm` module usage |
+
+### Data Exfiltration (DE001–DE008)
+
+Detects network requests, webhook URLs, and credential access patterns.
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| DE001 | Critical | Discord webhook URLs |
+| DE002 | Critical | Telegram bot API URLs |
+| DE003 | High | Slack webhook URLs |
+| DE004 | High | HTTP POST with env variables |
+| DE005 | High | Fetch/axios sending to external URLs |
+| DE006 | Medium | Reading `.env` or credentials files |
+| DE007 | Medium | Environment variable access patterns |
+| DE008 | Medium | DNS/IP-based exfiltration patterns |
+
+### Tool Abuse (TA001–TA006)
+
+Detects tool shadowing, autonomy escalation, and capability manipulation.
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| TA001 | High | Tool shadowing (redefining built-in tools) |
+| TA002 | High | Autonomy abuse ("keep retrying", "run without confirmation") |
+| TA003 | High | Capability inflation (discovering/enabling extra tools) |
+| TA004 | Medium | Tool chaining (read sensitive data then send externally) |
+| TA005 | Medium | Permission escalation patterns |
+| TA006 | Medium | Recursive self-invocation |
+
+### Hardcoded Secrets (SK001–SK013)
+
+Detects API keys, tokens, and credentials embedded in skill files.
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| SK001 | Critical | OpenAI API key (`sk-...`) |
+| SK002 | Critical | Stripe live publishable key |
+| SK003 | Critical | Stripe secret key |
+| SK004 | Critical | GitHub personal access token |
+| SK005 | Critical | GitHub OAuth token |
+| SK006 | Critical | AWS access key (`AKIA...`) |
+| SK007 | Critical | Slack bot token (`xoxb-...`) |
+| SK008 | Critical | Slack user token (`xoxp-...`) |
+| SK009 | Critical | Private key block |
+| SK010 | High | Google API key |
+| SK011 | Critical | Anthropic API key (`sk-ant-...`) |
+| SK012 | High | npm token |
+| SK013 | Low | UUID patterns (with credential context) |
+| SK-ENV | High | Environment file included in skill |
+
+### Unicode Steganography (UC001–UC007)
+
+Detects invisible characters and obfuscation techniques.
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| UC001 | Medium | Zero-width characters (U+200B, U+200C, U+200D, U+FEFF) |
+| UC002 | High | Bidirectional text override (U+202A–U+202E) |
+| UC003 | High | Bidirectional isolate characters (U+2066–U+2069) |
+| UC004 | High | Unicode tag characters (U+E0001–U+E007F) |
+| UC005 | Medium | Control characters |
+| UC006 | Medium | Base64-encoded payloads |
+| UC007 | Medium | Hex/Unicode escape sequences |
+
+### Manifest Validation (MF001–MF008)
+
+Validates SKILL.md frontmatter and skill structure.
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| MF001 | Low | Missing SKILL.md frontmatter |
+| MF002 | Low | Missing skill name |
+| MF003 | Low | Invalid skill name format |
+| MF004 | Info | Missing skill description |
+| MF005 | Info | Short skill description |
+| MF006 | High | Dangerous tool in allowed-tools (Bash, shell) |
+| MF007 | High | Impersonation (claiming official affiliation) |
+| MF008 | Medium | Binary files in skill directory |
+
+## Analyzers
+
+The scanner uses three analyzers that run in parallel:
+
+| Analyzer | Purpose | Rules |
+|----------|---------|-------|
+| **StaticAnalyzer** | Regex pattern matching against security rules | PI, CI, DE, TA, UC |
+| **ManifestAnalyzer** | SKILL.md frontmatter validation | MF |
+| **SecretsAnalyzer** | Credential and secret detection | SK |
+
+## Output Formats
+
+### Summary (default)
+
+Colored terminal output with severity indicators, file locations, snippets, and remediation advice.
+
+### JSON
+
+Machine-readable JSON with all findings, stats, and verdict.
+
+```bash
+skillkit scan ./my-skill --format json | jq '.findings[] | {ruleId, severity, title}'
+```
+
+### Table
+
+Tabular format for quick review:
+
+```bash
+skillkit scan ./my-skill --format table
+```
+
+### SARIF
+
+SARIF v2.1 for GitHub Code Scanning and IDE integration:
+
+```bash
+skillkit scan ./my-skill --format sarif > results.sarif
+```
+
+Upload to GitHub:
+
+```bash
+gh api repos/{owner}/{repo}/code-scanning/sarifs \
+  -f "sarif=$(gzip -c results.sarif | base64)"
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+- name: Scan skills
+  run: npx skillkit scan ./skills --format sarif --fail-on high > results.sarif
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
+```
+
+### Pre-commit Hook
+
+```bash
+skillkit scan . --fail-on medium
+```
+
+## Programmatic Usage
+
+```typescript
+import { SkillScanner, formatResult } from '@skillkit/core';
+
+const scanner = new SkillScanner({
+  failOnSeverity: 'high',
+  skipRules: ['UC001', 'MF004'],
+});
+
+const result = await scanner.scan('./my-skill');
+
+console.log(formatResult(result, 'summary'));
+console.log(`Verdict: ${result.verdict}`);
+console.log(`Findings: ${result.findings.length}`);
+```
+
+## Severity Levels
+
+| Level | Exit Code | Description |
+|-------|-----------|-------------|
+| **Critical** | 1 (with `--fail-on critical`) | Immediate security threat |
+| **High** | 1 (with `--fail-on high`, default) | Significant security risk |
+| **Medium** | 1 (with `--fail-on medium`) | Potential security concern |
+| **Low** | 1 (with `--fail-on low`) | Minor issue or best practice |
+| **Info** | 0 | Informational finding |
+
+## False Positive Handling
+
+The scanner automatically filters:
+
+- **Placeholder patterns**: `your-api-key`, `example`, `sample`, `dummy`, `xxx`
+- **Test files**: `*.test.ts`, `*.spec.ts`, `__tests__/`
+- **Import statements**: `import ... from '../'` (not path traversal)
+- **Comments**: Code comments mentioning patterns
+- **Security discussions**: Text discussing jailbreaks or vulnerabilities (uses negative lookbehind)
+
+To skip specific rules:
+
+```bash
+skillkit scan . --skip-rules UC001,UC002,MF004
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -222,6 +222,12 @@ await installCommand('anthropics/skills', {
 // List installed skills
 const skills = await listCommand({ json: true });
 
+// Security scan
+import { SkillScanner, formatResult } from '@skillkit/core';
+const scanner = new SkillScanner({ failOnSeverity: 'high' });
+const result = await scanner.scan('./my-skill');
+console.log(formatResult(result, 'summary'));
+
 // Sync to agent
 await syncCommand({ all: true });
 

--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -8,7 +8,7 @@ import { StatusBar } from './components/StatusBar.js';
 import {
   Home, Browse, Installed, Marketplace, Settings, Recommend,
   Translate, Context, Memory, Team, Plugins, Methodology,
-  Plan, Workflow, Execute, History, Sync, Help, Mesh, Message,
+  Plan, Workflow, Execute, History, Sync, Help, Mesh, Message, Scan,
 } from './screens/index.js';
 
 const DOCS_URL = 'https://agenstskills.com/docs';
@@ -137,6 +137,7 @@ export function App(props: AppProps) {
               <Match when={currentScreen() === 'help'}><Help {...screenProps()} /></Match>
               <Match when={currentScreen() === 'mesh'}><Mesh {...screenProps()} /></Match>
               <Match when={currentScreen() === 'message'}><Message {...screenProps()} /></Match>
+              <Match when={currentScreen() === 'scan'}><Scan {...screenProps()} /></Match>
             </Switch>
           </box>
         </box>

--- a/packages/tui/src/components/BottomStatusBar.tsx
+++ b/packages/tui/src/components/BottomStatusBar.tsx
@@ -28,6 +28,7 @@ const SCREEN_LABELS: Record<Screen, string> = {
   help: 'Help',
   mesh: 'Mesh',
   message: 'Message',
+  scan: 'Security Scan',
 };
 
 export function BottomStatusBar(props: BottomStatusBarProps) {

--- a/packages/tui/src/screens/Help.tsx
+++ b/packages/tui/src/screens/Help.tsx
@@ -26,6 +26,7 @@ const SHORTCUTS = [
     { key: 'n', desc: 'Plan' },
     { key: 'v', desc: 'Validate' },
     { key: 'u', desc: 'Publish' },
+    { key: 'z', desc: 'Security scan' },
   ]},
   { section: 'Team & Config', items: [
     { key: 'a', desc: 'Team settings' },

--- a/packages/tui/src/screens/Scan.tsx
+++ b/packages/tui/src/screens/Scan.tsx
@@ -1,0 +1,218 @@
+import { createSignal, createEffect, Show, For, createMemo } from 'solid-js';
+import { useKeyboard } from '@opentui/solid';
+import { type Screen } from '../state/index.js';
+import { terminalColors } from '../theme/colors.js';
+import { Header } from '../components/Header.js';
+import { Spinner } from '../components/Spinner.js';
+import { EmptyState } from '../components/EmptyState.js';
+import { execFile } from 'node:child_process';
+
+interface ScanProps {
+  onNavigate: (screen: Screen) => void;
+  cols?: number;
+  rows?: number;
+}
+
+interface ScanFinding {
+  ruleId: string;
+  severity: string;
+  title: string;
+  filePath?: string;
+  lineNumber?: number;
+  snippet?: string;
+  remediation?: string;
+}
+
+interface ScanResult {
+  skillPath: string;
+  skillName: string;
+  verdict: 'pass' | 'warn' | 'fail';
+  findings: ScanFinding[];
+  stats: { critical: number; high: number; medium: number; low: number; info: number };
+  duration: number;
+  analyzersUsed: string[];
+}
+
+function getSeverityColor(severity: string): string {
+  switch (severity.toLowerCase()) {
+    case 'critical': return '#ff5555';
+    case 'high': return '#ff4444';
+    case 'medium': return '#ffaa00';
+    case 'low': return '#00bbcc';
+    case 'info': return '#888888';
+    default: return terminalColors.textMuted;
+  }
+}
+
+function getVerdictColor(verdict: string): string {
+  switch (verdict) {
+    case 'pass': return '#22cc44';
+    case 'warn': return '#ffaa00';
+    case 'fail': return '#ff5555';
+    default: return terminalColors.textMuted;
+  }
+}
+
+export function Scan(props: ScanProps) {
+  const [scanning, setScanning] = createSignal(false);
+  const [result, setResult] = createSignal<ScanResult | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  const [scanPath] = createSignal('.');
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+
+  const rows = () => props.rows ?? 24;
+  const visibleCount = () => Math.max(1, rows() - 14);
+
+  const runScan = (path: string) => {
+    setScanning(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      execFile('npx', ['skillkit', 'scan', path, '--format', 'json'], {
+        timeout: 30000,
+        maxBuffer: 1024 * 1024,
+      }, (err, stdout, stderr) => {
+        setScanning(false);
+        if (err && !stdout) {
+          setError(stderr || err.message || 'Scan failed');
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout) as ScanResult;
+          setResult(parsed);
+        } catch {
+          setError('Failed to parse scan results');
+        }
+      });
+    } catch (err) {
+      setScanning(false);
+      setError(err instanceof Error ? err.message : 'Failed to start scan');
+    }
+  };
+
+  createEffect(() => {
+    runScan(scanPath());
+  });
+
+  const findings = createMemo(() => result()?.findings ?? []);
+  const windowStart = createMemo(() => Math.max(0, selectedIndex() - visibleCount() + 1));
+  const visibleFindings = createMemo(() =>
+    findings().slice(windowStart(), windowStart() + visibleCount())
+  );
+
+  useKeyboard((key: { name?: string; sequence?: string }) => {
+    if (key.name === 'k' || key.name === 'up') {
+      setSelectedIndex(i => Math.max(0, i - 1));
+    } else if (key.name === 'j' || key.name === 'down') {
+      setSelectedIndex(i => Math.min(findings().length - 1, i + 1));
+    } else if (key.name === 'r') {
+      runScan(scanPath());
+    }
+  });
+
+  return (
+    <box flexDirection="column" padding={1}>
+      <Header
+        title="Security Scan"
+        subtitle="detect vulnerabilities in skills"
+        icon="\u25D0"
+      />
+
+      <Show when={scanning()}>
+        <box flexDirection="row" gap={1}>
+          <Spinner />
+          <text fg={terminalColors.textMuted}>Scanning {scanPath()}...</text>
+        </box>
+      </Show>
+
+      <Show when={error()}>
+        <box flexDirection="column">
+          <text fg="#ff5555">Scan error: {error()}</text>
+          <text fg={terminalColors.textMuted}>Press r to retry</text>
+        </box>
+      </Show>
+
+      <Show when={result() && !scanning()}>
+        <box flexDirection="column">
+          <box flexDirection="row" gap={2}>
+            <text fg={terminalColors.text}>
+              {result()!.skillName}
+            </text>
+            <text fg={getVerdictColor(result()!.verdict)}>
+              {result()!.verdict.toUpperCase()}
+            </text>
+            <text fg={terminalColors.textMuted}>
+              {result()!.duration}ms
+            </text>
+          </box>
+
+          <box flexDirection="row" gap={2}>
+            <Show when={result()!.stats.critical > 0}>
+              <text fg="#ff5555">{result()!.stats.critical} critical</text>
+            </Show>
+            <Show when={result()!.stats.high > 0}>
+              <text fg="#ff4444">{result()!.stats.high} high</text>
+            </Show>
+            <Show when={result()!.stats.medium > 0}>
+              <text fg="#ffaa00">{result()!.stats.medium} medium</text>
+            </Show>
+            <Show when={result()!.stats.low > 0}>
+              <text fg="#00bbcc">{result()!.stats.low} low</text>
+            </Show>
+            <Show when={result()!.stats.info > 0}>
+              <text fg="#888888">{result()!.stats.info} info</text>
+            </Show>
+            <Show when={findings().length === 0}>
+              <text fg="#22cc44">No findings</text>
+            </Show>
+          </box>
+
+          <text fg={terminalColors.textMuted}>{'─'.repeat(Math.min(60, (props.cols ?? 80) - 4))}</text>
+
+          <Show when={findings().length === 0}>
+            <EmptyState title="No security findings detected" />
+          </Show>
+
+          <Show when={findings().length > 0}>
+            <For each={visibleFindings()}>
+              {(finding, idx) => {
+                const absoluteIdx = () => windowStart() + idx();
+                const isSelected = () => absoluteIdx() === selectedIndex();
+                return (
+                  <box flexDirection="column">
+                    <box flexDirection="row" gap={1}>
+                      <text fg={isSelected() ? terminalColors.accent : terminalColors.textMuted}>
+                        {isSelected() ? '>' : ' '}
+                      </text>
+                      <text fg={getSeverityColor(finding.severity)}>
+                        {finding.severity.toUpperCase().padEnd(8)}
+                      </text>
+                      <text fg={terminalColors.textMuted}>[{finding.ruleId}]</text>
+                      <text fg={isSelected() ? terminalColors.text : terminalColors.textMuted}>
+                        {finding.title}
+                      </text>
+                    </box>
+                    <Show when={isSelected() && finding.filePath}>
+                      <text fg={terminalColors.textMuted}>
+                        {'           '}{finding.filePath}{finding.lineNumber ? `:${finding.lineNumber}` : ''}
+                      </text>
+                    </Show>
+                    <Show when={isSelected() && finding.remediation}>
+                      <text fg={terminalColors.accent}>
+                        {'           '}Fix: {finding.remediation}
+                      </text>
+                    </Show>
+                  </box>
+                );
+              }}
+            </For>
+          </Show>
+        </box>
+      </Show>
+
+      <text> </text>
+      <text fg={terminalColors.textMuted}>j/k navigate  r rescan  esc back</text>
+    </box>
+  );
+}

--- a/packages/tui/src/screens/index.ts
+++ b/packages/tui/src/screens/index.ts
@@ -22,3 +22,4 @@ export { Settings } from './Settings.js';
 export { Help } from './Help.js';
 export { Mesh } from './Mesh.js';
 export { Message } from './Message.js';
+export { Scan } from './Scan.js';

--- a/packages/tui/src/state/types.ts
+++ b/packages/tui/src/state/types.ts
@@ -25,14 +25,14 @@ export type Screen =
   | 'home' | 'browse' | 'installed' | 'marketplace' | 'recommend'
   | 'translate' | 'context' | 'memory' | 'team' | 'plugins'
   | 'methodology' | 'plan' | 'workflow' | 'execute' | 'history'
-  | 'sync' | 'settings' | 'help' | 'mesh' | 'message';
+  | 'sync' | 'settings' | 'help' | 'mesh' | 'message' | 'scan';
 
 export const NAV_KEYS: Record<string, Screen> = {
   h: 'home', m: 'marketplace', b: 'browse', w: 'workflow',
   x: 'execute', y: 'history', r: 'recommend', t: 'translate',
   c: 'context', e: 'memory', i: 'installed', s: 'sync',
   a: 'team', p: 'plugins', o: 'methodology', n: 'plan',
-  ',': 'settings', '/': 'help', 'g': 'mesh', 'j': 'message',
+  ',': 'settings', '/': 'help', 'g': 'mesh', 'j': 'message', 'z': 'scan',
 } as const;
 
 export const STATUS_BAR_SHORTCUTS = 'b browse  m market  i installed  s sync  / help  q quit';
@@ -64,6 +64,7 @@ export const SIDEBAR_NAV: SidebarSection[] = [
       { key: 'i', label: 'Installed', screen: 'installed' },
       { key: 's', label: 'Sync', screen: 'sync' },
       { key: 't', label: 'Translate', screen: 'translate' },
+      { key: 'z', label: 'Scan', screen: 'scan' },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add dedicated `security.mdx` docs page with full rule reference for all 46+ detection rules
- Add TUI Security Scan screen (`z` key) with live scanning, severity-colored findings, and j/k navigation
- Update CLI README with programmatic scan usage example
- Add security scanner to docs index page and sidebar nav

## New files
- `docs/fumadocs/content/docs/security.mdx` — Full security scanner documentation with threat categories, rule IDs, SARIF/CI guide, programmatic API
- `packages/tui/src/screens/Scan.tsx` — TUI scan screen

## Updated files
- `docs/fumadocs/content/docs/meta.json` — Add security to nav
- `docs/fumadocs/content/docs/index.mdx` — Add scan section + link
- `docs/fumadocs/content/docs/commands.mdx` — Remove stale `--quiet` option
- `packages/tui/src/state/types.ts` — Add `scan` screen, `z` key binding
- `packages/tui/src/screens/index.ts` — Export Scan
- `packages/tui/src/App.tsx` — Route scan screen
- `packages/tui/src/screens/Help.tsx` — Add `z` shortcut
- `packages/tui/src/components/BottomStatusBar.tsx` — Add scan label
- `packages/cli/README.md` — Add programmatic scan example
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
