### PR TITLE
docs: Chrome extension — website button, fumadocs, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **SkillKit** is the open source package manager for AI agent skills. Write a skill once, deploy it to **44 agents** — Claude, Cursor, Copilot, Windsurf, Devin, Codex, and 38 more. No rewrites. 15,000+ skills in the marketplace.
 
-[Website](https://agenstskills.com) &middot; [Docs](https://agenstskills.com/docs) &middot; [API Explorer](https://agenstskills.com/api) &middot; [npm](https://www.npmjs.com/package/skillkit)
+[Website](https://agenstskills.com) &middot; [Docs](https://agenstskills.com/docs) &middot; [API Explorer](https://agenstskills.com/api) &middot; [Chrome Extension](https://github.com/rohitg00/skillkit/tree/main/packages/extension#readme) &middot; [npm](https://www.npmjs.com/package/skillkit)
 
 </div>
 
@@ -180,6 +180,18 @@ git commit -m "add team skills"
 ```
 
 Team members run `skillkit manifest install` and they're in sync.
+
+### Chrome Extension
+
+Save any webpage as a skill directly from your browser. No server needed.
+
+1. Build: `pnpm --filter @skillkit/extension build`
+2. Chrome → `chrome://extensions` → Load unpacked → `packages/extension/dist/`
+3. Click the extension icon or right-click → "Save page as Skill"
+
+The extension extracts page content as markdown, generates SKILL.md with auto-detected tags, and downloads it. Then run `skillkit install ~/Downloads/skillkit-skills/my-skill` to deploy to all agents.
+
+[Extension docs](https://agenstskills.com/docs/chrome-extension)
 
 ### Interactive TUI
 

--- a/docs/fumadocs/content/docs/chrome-extension.mdx
+++ b/docs/fumadocs/content/docs/chrome-extension.mdx
@@ -1,0 +1,119 @@
+---
+title: Chrome Extension
+description: Save any webpage as an AI agent skill from your browser
+---
+
+# Chrome Extension
+
+Save any webpage as a SKILL.md directly from your browser. No server needed.
+
+## Install
+
+1. Download the extension from the [releases page](https://github.com/rohitg00/skillkit/releases)
+2. Open `chrome://extensions` in Chrome
+3. Enable "Developer mode" (top right)
+4. Click "Load unpacked" and select the `packages/extension/dist/` folder
+
+Or build from source:
+
+```bash
+git clone https://github.com/rohitg00/skillkit.git
+cd skillkit
+pnpm install && pnpm --filter @skillkit/extension build
+```
+
+Then load `packages/extension/dist/` as an unpacked extension.
+
+## Usage
+
+### Popup
+
+1. Navigate to any webpage
+2. Click the SkillKit extension icon
+3. Optionally enter a custom skill name
+4. Click **Save as Skill**
+
+The extension extracts the page content as markdown, generates a SKILL.md with YAML frontmatter and auto-detected tags, and downloads it to your `Downloads/skillkit-skills/` folder.
+
+### Context Menu
+
+Right-click on any page:
+
+- **Save page as Skill** — saves the entire page
+- **Save selection as Skill** — saves only the selected text
+
+### Making Skills Available to Agents
+
+After downloading, install the skill so all agents can use it:
+
+```bash
+skillkit install ~/Downloads/skillkit-skills/my-skill
+```
+
+Or copy directly:
+
+```bash
+cp -r ~/Downloads/skillkit-skills/my-skill ~/.skillkit/skills/
+skillkit sync
+```
+
+## How It Works
+
+The extension runs entirely in the browser:
+
+1. **Content script** extracts page content using [Turndown](https://github.com/mixmark-io/turndown) to convert HTML to clean markdown. It targets `<article>`, `<main>`, or `<body>` and strips scripts, nav, footer, and iframes.
+
+2. **Background service worker** generates the SKILL.md:
+   - Slugifies the page title into a skill name
+   - Builds YAML frontmatter (name, description, source URL, timestamp)
+   - Auto-detects tags from 40+ tech keywords (react, typescript, docker, kubernetes, etc.)
+   - Downloads via `chrome.downloads` API
+
+3. **No server required** — the `POST /save` API endpoint exists for CLI users (`skillkit save`), but the extension works independently.
+
+## Permissions
+
+| Permission | Why |
+|-----------|-----|
+| `contextMenus` | Right-click "Save as Skill" menu items |
+| `activeTab` | Access current page URL and title |
+| `storage` | Persist extension preferences |
+| `downloads` | Save SKILL.md files to disk |
+
+No `host_permissions` needed. The extension never sends data to any server.
+
+## Generated SKILL.md Format
+
+```yaml
+---
+name: react-performance-tips
+description: Optimizing React rendering with memo and useMemo
+tags:
+  - react
+  - javascript
+  - testing
+metadata:
+  source: https://example.com/react-performance
+  savedAt: 2026-02-10T09:00:00.000Z
+---
+
+# React Performance Tips
+
+The extracted markdown content of the page...
+```
+
+## Building from Source
+
+The extension uses tsup to bundle TypeScript into IIFE format for browser compatibility:
+
+```bash
+pnpm --filter @skillkit/extension build
+```
+
+Output goes to `packages/extension/dist/` with:
+- `background.global.js` — Service worker (5KB)
+- `content.global.js` — Content script with Turndown (23KB)
+- `popup.global.js` — Popup UI logic (3KB)
+- `popup.html` + `popup.css` — Monochromatic UI
+- `manifest.json` — Chrome Manifest V3
+- `icons/` — 16/48/128px PNG icons

--- a/docs/fumadocs/content/docs/meta.json
+++ b/docs/fumadocs/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "installation",
+    "chrome-extension",
     "quickstart",
     "tui",
     "skills",

--- a/docs/skillkit/App.tsx
+++ b/docs/skillkit/App.tsx
@@ -98,6 +98,14 @@ export default function App(): React.ReactElement {
               >
                 Generator
               </a>
+              <a
+                href="https://github.com/rohitg00/skillkit/tree/main/packages/extension#readme"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-zinc-500 hover:text-white transition-colors"
+              >
+                Extension
+              </a>
             </div>
             <div className="flex items-center gap-3 sm:gap-4">
               <a

--- a/docs/skillkit/components/Hero.tsx
+++ b/docs/skillkit/components/Hero.tsx
@@ -173,6 +173,19 @@ export function Hero({ version, stars }: HeroProps): React.ReactElement {
                   )}
                 </span>
               </button>
+              <a
+                href="https://github.com/rohitg00/skillkit/tree/main/packages/extension#readme"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 bg-white text-black border border-zinc-300 px-3 py-2 hover:bg-zinc-200 transition-colors font-mono text-sm font-semibold"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none">
+                  <circle cx="12" cy="12" r="10" fill="#09090b"/>
+                  <circle cx="12" cy="12" r="4.5" fill="white"/>
+                  <path d="M12 2v5.5M12 16.5V22M2 12h5.5M16.5 12H22" stroke="white" strokeWidth="1.5"/>
+                </svg>
+                Add to Chrome
+              </a>
               <button
                 onClick={openGitHub}
                 className="inline-flex items-center gap-2 border border-zinc-700 px-3 py-2 hover:border-zinc-500 transition-colors group"

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,0 +1,46 @@
+# @skillkit/extension
+
+Chrome extension to save any webpage as an AI agent skill. No server needed.
+
+## Install
+
+```bash
+pnpm --filter @skillkit/extension build
+```
+
+Then in Chrome:
+
+1. Open `chrome://extensions`
+2. Enable "Developer mode"
+3. Click "Load unpacked"
+4. Select `packages/extension/dist/`
+
+## Usage
+
+- Click the extension icon → **Save as Skill**
+- Right-click any page → **Save page as Skill**
+- Select text → right-click → **Save selection as Skill**
+
+Skills download to `Downloads/skillkit-skills/{name}/SKILL.md`.
+
+To make available to all 44 agents:
+
+```bash
+skillkit install ~/Downloads/skillkit-skills/my-skill
+```
+
+## How It Works
+
+Everything runs in the browser:
+
+1. **Content script** converts page HTML to markdown via Turndown
+2. **Background worker** generates SKILL.md with YAML frontmatter and auto-tags
+3. **Downloads API** saves the file — no server calls
+
+## Build
+
+```bash
+pnpm --filter @skillkit/extension build
+```
+
+Output: `dist/` with manifest, JS bundles (IIFE), popup UI, and icons.


### PR DESCRIPTION
## Summary

- **Website Hero** — white "Add to Chrome" button between install command and GitHub star button, wraps naturally on mobile via `flex flex-wrap`
- **Website navbar** — "Extension" link in desktop nav (hidden on mobile, same as other nav links)
- **Fumadocs** — new `chrome-extension.mdx` page with install, usage, context menu, architecture, permissions table, SKILL.md format example, and build docs
- **README** — Chrome extension section with build/install/usage steps, plus "Chrome Extension" link in header nav
- **Extension README** — `packages/extension/README.md` with setup and usage guide

## Test plan
- [x] `pnpm build` — All 13 packages compile
- [x] `pnpm test` — All 25 tasks pass
- [ ] Website: "Add to Chrome" button visible and wraps on mobile
- [ ] Website: navbar "Extension" link scrolls/navigates correctly
- [ ] Fumadocs: chrome-extension page renders in docs navigation
- [ ] README: Chrome extension section renders on GitHub
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
