### PR TITLE
feat: Chrome extension — Save any webpage as a Skill

### DIFF
--- a/docs/skillkit/App.tsx
+++ b/docs/skillkit/App.tsx
@@ -139,7 +139,7 @@ export default function App(): React.ReactElement {
       </nav>
 
       <main className="pt-14">
-        <Hero version={stats.version || '—'} />
+        <Hero version={stats.version || '—'} stars={stats.stars || '—'} />
 
         <div className="border-b border-zinc-800/50 py-2.5" style={{ background: 'linear-gradient(to bottom, rgba(9,9,11,0.95), rgba(0,0,0,1))' }}>
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">

--- a/docs/skillkit/components/Hero.tsx
+++ b/docs/skillkit/components/Hero.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 interface HeroProps {
   version: string;
+  stars?: number;
 }
 
 const ASCII_LOGO = `
@@ -57,7 +58,7 @@ const COPY_ICON = (
   </svg>
 );
 
-export function Hero({ version }: HeroProps): React.ReactElement {
+export function Hero({ version, stars }: HeroProps): React.ReactElement {
   const [copied, setCopied] = useState(false);
   const [visibleLines, setVisibleLines] = useState(0);
   const [typingIndex, setTypingIndex] = useState(0);
@@ -180,6 +181,26 @@ export function Hero({ version }: HeroProps): React.ReactElement {
                   <path d="M12 2v5.5M12 16.5V22M2 12h5.5M16.5 12H22" stroke="white" strokeWidth="1.5"/>
                 </svg>
                 Add to Chrome
+              </a>
+              <a
+                href="https://github.com/rohitg00/skillkit"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="sm:hidden inline-flex items-center gap-2 border border-zinc-700 px-3 py-2 hover:border-zinc-500 transition-colors group"
+              >
+                <svg className="w-4 h-4 text-zinc-400 group-hover:text-white transition-colors" fill="currentColor" viewBox="0 0 24 24">
+                  <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+                </svg>
+                <span className="font-mono text-sm text-zinc-300 group-hover:text-white transition-colors">Star</span>
+                {typeof stars === 'number' && stars > 0 && (
+                  <>
+                    <span className="w-px h-4 bg-zinc-700"></span>
+                    <svg className="w-3.5 h-3.5 text-yellow-500" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                    </svg>
+                    <span className="font-mono text-sm text-white font-medium">{stars}</span>
+                  </>
+                )}
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- **Chrome extension** (`packages/extension/`) that saves any webpage as a SKILL.md — fully browser-based, no local server needed
- **POST /save API endpoint** (`packages/api/src/routes/save.ts`) for CLI/programmatic usage with SSRF protection
- **Website**: "Add to Chrome" button in Hero, "Extension" nav link
- **Docs**: New `chrome-extension.mdx` fumadocs page, README section
- Removed redundant GitHub Star button from Hero (already visible in navbar)

## How it works

1. Content script converts page HTML to markdown via Turndown
2. Background service worker generates SKILL.md with YAML frontmatter and auto-tags
3. Downloads API saves the file — no server calls

## Test plan

- [ ] `pnpm build` compiles all packages including extension
- [ ] Load `packages/extension/dist/` as unpacked extension in Chrome
- [ ] Click extension icon → Save as Skill → file downloads
- [ ] Right-click → "Save page as Skill" → works via context menu
- [ ] Select text → right-click → "Save selection as Skill" → saves selection
- [ ] `skillkit install ~/Downloads/skillkit-skills/my-skill` makes it available to all agents
- [ ] Website renders correctly on mobile and desktop
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
