### PR TITLE
feat: add TUI screens for session intelligence

### DIFF
--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -9,6 +9,7 @@ import {
   Home, Browse, Installed, Marketplace, Settings, Recommend,
   Translate, Context, Memory, Team, Plugins, Methodology,
   Plan, Workflow, Execute, History, Sync, Help, Mesh, Message, Scan,
+  Timeline, Lineage, Handoff,
 } from './screens/index.js';
 
 const DOCS_URL = 'https://agenstskills.com/docs';
@@ -138,6 +139,9 @@ export function App(props: AppProps) {
               <Match when={currentScreen() === 'mesh'}><Mesh {...screenProps()} /></Match>
               <Match when={currentScreen() === 'message'}><Message {...screenProps()} /></Match>
               <Match when={currentScreen() === 'scan'}><Scan {...screenProps()} /></Match>
+              <Match when={currentScreen() === 'timeline'}><Timeline {...screenProps()} /></Match>
+              <Match when={currentScreen() === 'lineage'}><Lineage {...screenProps()} /></Match>
+              <Match when={currentScreen() === 'handoff'}><Handoff {...screenProps()} /></Match>
             </Switch>
           </box>
         </box>

--- a/packages/tui/src/components/BottomStatusBar.tsx
+++ b/packages/tui/src/components/BottomStatusBar.tsx
@@ -29,6 +29,9 @@ const SCREEN_LABELS: Record<Screen, string> = {
   mesh: 'Mesh',
   message: 'Message',
   scan: 'Security Scan',
+  timeline: 'Timeline',
+  lineage: 'Lineage',
+  handoff: 'Handoff',
 };
 
 export function BottomStatusBar(props: BottomStatusBarProps) {

--- a/packages/tui/src/screens/Handoff.tsx
+++ b/packages/tui/src/screens/Handoff.tsx
@@ -1,0 +1,231 @@
+import { createSignal, createEffect, Show, For } from 'solid-js';
+import { useKeyboard } from '@opentui/solid';
+import { type Screen } from '../state/index.js';
+import { terminalColors } from '../theme/colors.js';
+import { Header } from '../components/Header.js';
+import { Spinner } from '../components/Spinner.js';
+import { EmptyState } from '../components/EmptyState.js';
+import { execFile } from 'node:child_process';
+
+function changeTypeLabel(changeType: string): string {
+  switch (changeType) {
+    case 'modified': return 'M';
+    case 'created': return 'A';
+    default: return 'D';
+  }
+}
+
+interface HandoffProps {
+  onNavigate: (screen: Screen) => void;
+  cols?: number;
+  rows?: number;
+}
+
+interface HandoffTask {
+  name: string;
+  duration?: string;
+  commitSha?: string;
+}
+
+interface HandoffCommit {
+  sha: string;
+  message: string;
+  filesCount: number;
+}
+
+interface HandoffResult {
+  generatedAt: string;
+  fromAgent: string;
+  projectPath: string;
+  accomplished: { tasks: HandoffTask[]; commits: HandoffCommit[] };
+  pending: { tasks: HandoffTask[]; commits: HandoffCommit[] };
+  keyFiles: Array<{ path: string; changeType: string }>;
+  observations: {
+    errors: Array<{ action: string; error: string }>;
+    solutions: Array<{ action: string; solution: string }>;
+    patterns: Array<{ action: string; context: string }>;
+  };
+  recommendations: string[];
+}
+
+type SectionView = 'accomplished' | 'pending' | 'files' | 'recommendations';
+
+export function Handoff(props: HandoffProps) {
+  const [loading, setLoading] = createSignal(true);
+  const [result, setResult] = createSignal<HandoffResult | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  const [section, setSection] = createSignal<SectionView>('accomplished');
+
+  const loadHandoff = () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      execFile('npx', ['skillkit', 'session', 'handoff', '--json'], {
+        timeout: 15000,
+        maxBuffer: 1024 * 1024,
+      }, (err, stdout, stderr) => {
+        setLoading(false);
+        if (err && !stdout) {
+          setError(stderr || err.message || 'Failed to generate handoff');
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout) as HandoffResult;
+          setResult(parsed);
+        } catch {
+          setError('Failed to parse handoff data');
+        }
+      });
+    } catch (err) {
+      setLoading(false);
+      setError(err instanceof Error ? err.message : 'Failed to generate handoff');
+    }
+  };
+
+  createEffect(() => {
+    loadHandoff();
+  });
+
+  const sections: SectionView[] = ['accomplished', 'pending', 'files', 'recommendations'];
+
+  useKeyboard((key: { name?: string }) => {
+    if (key.name === 'tab') {
+      const idx = sections.indexOf(section());
+      setSection(sections[(idx + 1) % sections.length]);
+    } else if (key.name === 'r') {
+      loadHandoff();
+    } else if (key.name === 'escape') {
+      props.onNavigate('home');
+    }
+  });
+
+  return (
+    <box flexDirection="column" padding={1}>
+      <Header
+        title="Handoff"
+        subtitle="agent-to-agent context transfer"
+        icon="⇄"
+      />
+
+      <Show when={loading()}>
+        <Spinner label="Generating handoff document..." />
+      </Show>
+
+      <Show when={error()}>
+        <box flexDirection="column">
+          <text fg="#ff5555">Error: {error()}</text>
+          <text fg={terminalColors.textMuted}>Press r to retry</text>
+        </box>
+      </Show>
+
+      <Show when={!loading() && !error() && result()}>
+        <box flexDirection="row" gap={1} marginBottom={1}>
+          <text fg={terminalColors.textMuted}>from:</text>
+          <text fg={terminalColors.text}>{result()!.fromAgent}</text>
+          <text fg={terminalColors.textMuted}>|</text>
+          <text fg={terminalColors.textMuted}>{result()!.generatedAt}</text>
+        </box>
+
+        <box flexDirection="row" gap={2} marginBottom={1}>
+          <For each={sections}>
+            {(s) => (
+              <text
+                fg={section() === s ? terminalColors.accent : terminalColors.textMuted}
+                bold={section() === s}
+              >
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </text>
+            )}
+          </For>
+          <text fg={terminalColors.textMuted}>(Tab to switch)</text>
+        </box>
+
+        <text fg={terminalColors.textMuted}>{'─'.repeat(Math.min(60, (props.cols ?? 80) - 4))}</text>
+
+        <Show when={section() === 'accomplished'}>
+          <text fg={terminalColors.text} bold>Accomplished Tasks</text>
+          <text> </text>
+          <Show when={result()!.accomplished.tasks.length === 0}>
+            <EmptyState title="No accomplished tasks in this session" />
+          </Show>
+          <For each={result()!.accomplished.tasks}>
+            {(task) => (
+              <box flexDirection="row" gap={1}>
+                <text fg="#22cc44">✓</text>
+                <text fg={terminalColors.text}>{task.name}</text>
+                <Show when={task.duration}>
+                  <text fg={terminalColors.textMuted}>({task.duration})</text>
+                </Show>
+              </box>
+            )}
+          </For>
+          <Show when={result()!.accomplished.commits.length > 0}>
+            <text> </text>
+            <text fg={terminalColors.text} bold>Commits</text>
+            <For each={result()!.accomplished.commits}>
+              {(commit) => (
+                <box flexDirection="row" gap={1}>
+                  <text fg="#fbbf24">●</text>
+                  <text fg={terminalColors.textMuted}>{commit.sha.slice(0, 7)}</text>
+                  <text fg={terminalColors.text}>{commit.message}</text>
+                </box>
+              )}
+            </For>
+          </Show>
+        </Show>
+
+        <Show when={section() === 'pending'}>
+          <text fg={terminalColors.text} bold>Pending Tasks</text>
+          <text> </text>
+          <Show when={result()!.pending.tasks.length === 0}>
+            <EmptyState title="No pending tasks" />
+          </Show>
+          <For each={result()!.pending.tasks}>
+            {(task) => (
+              <box flexDirection="row" gap={1}>
+                <text fg="#ffaa00">○</text>
+                <text fg={terminalColors.text}>{task.name}</text>
+              </box>
+            )}
+          </For>
+        </Show>
+
+        <Show when={section() === 'files'}>
+          <text fg={terminalColors.text} bold>Key Files</text>
+          <text> </text>
+          <Show when={result()!.keyFiles.length === 0}>
+            <EmptyState title="No key files tracked" />
+          </Show>
+          <For each={result()!.keyFiles}>
+            {(file) => (
+              <box flexDirection="row" gap={1}>
+                <text fg={terminalColors.textMuted}>{changeTypeLabel(file.changeType)}</text>
+                <text fg={terminalColors.text}>{file.path}</text>
+              </box>
+            )}
+          </For>
+        </Show>
+
+        <Show when={section() === 'recommendations'}>
+          <text fg={terminalColors.text} bold>Recommendations</text>
+          <text> </text>
+          <Show when={result()!.recommendations.length === 0}>
+            <EmptyState title="No recommendations" />
+          </Show>
+          <For each={result()!.recommendations}>
+            {(rec) => (
+              <box flexDirection="row" gap={1}>
+                <text fg={terminalColors.accent}>→</text>
+                <text fg={terminalColors.text}>{rec}</text>
+              </box>
+            )}
+          </For>
+        </Show>
+      </Show>
+
+      <text> </text>
+      <text fg={terminalColors.textMuted}>Tab switch section  r refresh  esc back</text>
+    </box>
+  );
+}

--- a/packages/tui/src/screens/Lineage.tsx
+++ b/packages/tui/src/screens/Lineage.tsx
@@ -1,0 +1,246 @@
+import { createSignal, createEffect, Show, For, createMemo } from 'solid-js';
+import { useKeyboard } from '@opentui/solid';
+import { type Screen } from '../state/index.js';
+import { terminalColors } from '../theme/colors.js';
+import { Header } from '../components/Header.js';
+import { Spinner } from '../components/Spinner.js';
+import { EmptyState } from '../components/EmptyState.js';
+import { execFile } from 'node:child_process';
+
+interface LineageProps {
+  onNavigate: (screen: Screen) => void;
+  cols?: number;
+  rows?: number;
+}
+
+interface SkillLineageEntry {
+  skillName: string;
+  executions: number;
+  totalDurationMs: number;
+  commits: string[];
+  filesModified: string[];
+  firstSeen: string;
+  lastSeen: string;
+}
+
+interface FileLineage {
+  path: string;
+  skills: string[];
+  commitCount: number;
+  lastModified: string;
+}
+
+interface LineageResult {
+  projectPath: string;
+  skills: SkillLineageEntry[];
+  files: FileLineage[];
+  stats: {
+    totalSkillExecutions: number;
+    totalCommits: number;
+    totalFilesChanged: number;
+    mostImpactfulSkill: string | null;
+    mostChangedFile: string | null;
+    errorProneFiles: string[];
+  };
+}
+
+type ViewMode = 'skills' | 'files';
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+}
+
+export function Lineage(props: LineageProps) {
+  const [loading, setLoading] = createSignal(true);
+  const [result, setResult] = createSignal<LineageResult | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  const [viewMode, setViewMode] = createSignal<ViewMode>('skills');
+
+  const rows = () => props.rows ?? 24;
+  const visibleCount = () => Math.max(1, rows() - 14);
+
+  const loadLineage = () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      execFile('npx', ['skillkit', 'lineage', '--json'], {
+        timeout: 15000,
+        maxBuffer: 1024 * 1024,
+      }, (err, stdout, stderr) => {
+        setLoading(false);
+        if (err && !stdout) {
+          setError(stderr || err.message || 'Failed to load lineage');
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout) as LineageResult;
+          setResult(parsed);
+        } catch {
+          setError('Failed to parse lineage data');
+        }
+      });
+    } catch (err) {
+      setLoading(false);
+      setError(err instanceof Error ? err.message : 'Failed to load lineage');
+    }
+  };
+
+  createEffect(() => {
+    loadLineage();
+  });
+
+  const items = createMemo(() => {
+    if (viewMode() === 'skills') return result()?.skills ?? [];
+    return result()?.files ?? [];
+  });
+
+  const windowStart = createMemo(() => Math.max(0, selectedIndex() - visibleCount() + 1));
+  const visibleItems = createMemo(() =>
+    items().slice(windowStart(), windowStart() + visibleCount())
+  );
+
+  useKeyboard((key: { name?: string }) => {
+    if (key.name === 'k' || key.name === 'up') {
+      setSelectedIndex(i => Math.max(0, i - 1));
+    } else if (key.name === 'j' || key.name === 'down') {
+      setSelectedIndex(i => items().length > 0 ? Math.min(items().length - 1, i + 1) : 0);
+    } else if (key.name === 'tab') {
+      setViewMode(m => m === 'skills' ? 'files' : 'skills');
+      setSelectedIndex(0);
+    } else if (key.name === 'r') {
+      loadLineage();
+    } else if (key.name === 'escape') {
+      props.onNavigate('home');
+    }
+  });
+
+  return (
+    <box flexDirection="column" padding={1}>
+      <Header
+        title="Lineage"
+        subtitle="skill impact graph"
+        icon="◉"
+      />
+
+      <Show when={loading()}>
+        <Spinner label="Loading lineage..." />
+      </Show>
+
+      <Show when={error()}>
+        <box flexDirection="column">
+          <text fg="#ff5555">Error: {error()}</text>
+          <text fg={terminalColors.textMuted}>Press r to retry</text>
+        </box>
+      </Show>
+
+      <Show when={!loading() && !error() && result()}>
+        <box flexDirection="row" gap={2} marginBottom={1}>
+          <text fg={terminalColors.text}>{result()!.stats.totalSkillExecutions} executions</text>
+          <text fg={terminalColors.textMuted}>|</text>
+          <text fg={terminalColors.text}>{result()!.stats.totalCommits} commits</text>
+          <text fg={terminalColors.textMuted}>|</text>
+          <text fg={terminalColors.text}>{result()!.stats.totalFilesChanged} files</text>
+          <Show when={result()!.stats.mostImpactfulSkill}>
+            <text fg={terminalColors.textMuted}>|</text>
+            <text fg="#22cc44">top: {result()!.stats.mostImpactfulSkill}</text>
+          </Show>
+        </box>
+
+        <box flexDirection="row" gap={2} marginBottom={1}>
+          <text
+            fg={viewMode() === 'skills' ? terminalColors.accent : terminalColors.textMuted}
+            bold={viewMode() === 'skills'}
+          >
+            Skills ({result()?.skills?.length ?? 0})
+          </text>
+          <text
+            fg={viewMode() === 'files' ? terminalColors.accent : terminalColors.textMuted}
+            bold={viewMode() === 'files'}
+          >
+            Files ({result()?.files?.length ?? 0})
+          </text>
+          <text fg={terminalColors.textMuted}>(Tab to switch)</text>
+        </box>
+
+        <text fg={terminalColors.textMuted}>{'─'.repeat(Math.min(60, (props.cols ?? 80) - 4))}</text>
+
+        <Show when={items().length === 0}>
+          <EmptyState
+            title={viewMode() === 'skills' ? 'No skill lineage data' : 'No file lineage data'}
+            description="Execute skills to build lineage history"
+          />
+        </Show>
+
+        <Show when={items().length > 0}>
+          <For each={visibleItems()}>
+            {(item, idx) => {
+              const absoluteIdx = () => windowStart() + idx();
+              const isSelected = () => absoluteIdx() === selectedIndex();
+
+              return (
+                <box flexDirection="column">
+                  <Show when={viewMode() === 'skills'}>
+                    {(() => {
+                      const skill = item as SkillLineageEntry;
+                      return (
+                        <box flexDirection="row" gap={1}>
+                          <text fg={isSelected() ? terminalColors.accent : terminalColors.textMuted}>
+                            {isSelected() ? '>' : ' '}
+                          </text>
+                          <text fg={isSelected() ? terminalColors.text : terminalColors.textMuted} width={24}>
+                            {skill.skillName}
+                          </text>
+                          <text fg={terminalColors.textMuted} width={8}>
+                            {skill.executions}x
+                          </text>
+                          <text fg={terminalColors.textMuted} width={8}>
+                            {formatDuration(skill.totalDurationMs)}
+                          </text>
+                          <text fg="#fbbf24" width={8}>
+                            {skill.commits.length} commits
+                          </text>
+                          <text fg={terminalColors.textMuted}>
+                            {skill.filesModified.length} files
+                          </text>
+                        </box>
+                      );
+                    })()}
+                  </Show>
+                  <Show when={viewMode() === 'files'}>
+                    {(() => {
+                      const file = item as FileLineage;
+                      return (
+                        <box flexDirection="row" gap={1}>
+                          <text fg={isSelected() ? terminalColors.accent : terminalColors.textMuted}>
+                            {isSelected() ? '>' : ' '}
+                          </text>
+                          <text fg={isSelected() ? terminalColors.text : terminalColors.textMuted} width={36}>
+                            {file.path}
+                          </text>
+                          <text fg="#fbbf24" width={10}>
+                            {file.commitCount} commits
+                          </text>
+                          <text fg={terminalColors.textMuted}>
+                            {file.skills.join(', ')}
+                          </text>
+                        </box>
+                      );
+                    })()}
+                  </Show>
+                </box>
+              );
+            }}
+          </For>
+        </Show>
+      </Show>
+
+      <text> </text>
+      <text fg={terminalColors.textMuted}>j/k navigate  Tab switch view  r refresh  esc back</text>
+    </box>
+  );
+}

--- a/packages/tui/src/screens/Timeline.tsx
+++ b/packages/tui/src/screens/Timeline.tsx
@@ -1,0 +1,189 @@
+import { createSignal, createEffect, Show, For, createMemo } from 'solid-js';
+import { useKeyboard } from '@opentui/solid';
+import { type Screen } from '../state/index.js';
+import { terminalColors } from '../theme/colors.js';
+import { Header } from '../components/Header.js';
+import { Spinner } from '../components/Spinner.js';
+import { EmptyState } from '../components/EmptyState.js';
+import { execFile } from 'node:child_process';
+
+interface TimelineProps {
+  onNavigate: (screen: Screen) => void;
+  cols?: number;
+  rows?: number;
+}
+
+interface TimelineEvent {
+  timestamp: string;
+  type: string;
+  source: string;
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+interface TimelineResult {
+  projectPath: string;
+  sessionDate: string;
+  events: TimelineEvent[];
+  totalCount: number;
+}
+
+function getTypeIcon(type: string): string {
+  switch (type) {
+    case 'skill_start': return '▶';
+    case 'skill_complete': return '✓';
+    case 'task_progress': return '◇';
+    case 'git_commit': return '●';
+    case 'observation': return '○';
+    case 'decision': return '◆';
+    case 'snapshot': return '◈';
+    default: return '•';
+  }
+}
+
+function getTypeColor(type: string): string {
+  switch (type) {
+    case 'skill_start': return '#22cc44';
+    case 'skill_complete': return '#22cc44';
+    case 'git_commit': return '#fbbf24';
+    case 'observation': return '#00bbcc';
+    case 'decision': return '#aa88ff';
+    case 'snapshot': return '#ff88aa';
+    default: return terminalColors.textMuted;
+  }
+}
+
+function formatTimestamp(ts: string): string {
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return ts;
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+  } catch {
+    return ts;
+  }
+}
+
+export function Timeline(props: TimelineProps) {
+  const [loading, setLoading] = createSignal(true);
+  const [result, setResult] = createSignal<TimelineResult | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+
+  const rows = () => props.rows ?? 24;
+  const visibleCount = () => Math.max(1, rows() - 10);
+
+  const loadTimeline = () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      execFile('npx', ['skillkit', 'timeline', '--json'], {
+        timeout: 15000,
+        maxBuffer: 1024 * 1024,
+      }, (err, stdout, stderr) => {
+        setLoading(false);
+        if (err && !stdout) {
+          setError(stderr || err.message || 'Failed to load timeline');
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout) as TimelineResult;
+          setResult(parsed);
+        } catch {
+          setError('Failed to parse timeline data');
+        }
+      });
+    } catch (err) {
+      setLoading(false);
+      setError(err instanceof Error ? err.message : 'Failed to load timeline');
+    }
+  };
+
+  createEffect(() => {
+    loadTimeline();
+  });
+
+  const events = createMemo(() => result()?.events ?? []);
+  const windowStart = createMemo(() => Math.max(0, selectedIndex() - visibleCount() + 1));
+  const visibleEvents = createMemo(() =>
+    events().slice(windowStart(), windowStart() + visibleCount())
+  );
+
+  useKeyboard((key: { name?: string }) => {
+    if (key.name === 'k' || key.name === 'up') {
+      setSelectedIndex(i => Math.max(0, i - 1));
+    } else if (key.name === 'j' || key.name === 'down') {
+      setSelectedIndex(i => events().length > 0 ? Math.min(events().length - 1, i + 1) : 0);
+    } else if (key.name === 'r') {
+      loadTimeline();
+    } else if (key.name === 'escape') {
+      props.onNavigate('home');
+    }
+  });
+
+  return (
+    <box flexDirection="column" padding={1}>
+      <Header
+        title="Timeline"
+        subtitle="unified event stream"
+        count={result()?.totalCount}
+        icon="▸"
+      />
+
+      <Show when={loading()}>
+        <Spinner label="Loading timeline..." />
+      </Show>
+
+      <Show when={error()}>
+        <box flexDirection="column">
+          <text fg="#ff5555">Error: {error()}</text>
+          <text fg={terminalColors.textMuted}>Press r to retry</text>
+        </box>
+      </Show>
+
+      <Show when={!loading() && !error()}>
+        <Show when={events().length === 0}>
+          <EmptyState
+            title="No timeline events"
+            description="Events appear as you execute skills and make commits"
+          />
+        </Show>
+
+        <Show when={events().length > 0}>
+          <For each={visibleEvents()}>
+            {(event, idx) => {
+              const absoluteIdx = () => windowStart() + idx();
+              const isSelected = () => absoluteIdx() === selectedIndex();
+              return (
+                <box flexDirection="column">
+                  <box flexDirection="row" gap={1}>
+                    <text fg={isSelected() ? terminalColors.accent : terminalColors.textMuted}>
+                      {isSelected() ? '>' : ' '}
+                    </text>
+                    <text fg={terminalColors.textMuted} width={9}>
+                      {formatTimestamp(event.timestamp)}
+                    </text>
+                    <text fg={getTypeColor(event.type)}>
+                      {getTypeIcon(event.type)}
+                    </text>
+                    <text fg={isSelected() ? terminalColors.text : terminalColors.textMuted}>
+                      {event.summary}
+                    </text>
+                  </box>
+                  <Show when={isSelected() && event.source}>
+                    <text fg={terminalColors.textMuted}>
+                      {'              '}source: {event.source}
+                    </text>
+                  </Show>
+                </box>
+              );
+            }}
+          </For>
+        </Show>
+      </Show>
+
+      <text> </text>
+      <text fg={terminalColors.textMuted}>j/k navigate  r refresh  esc back</text>
+    </box>
+  );
+}

--- a/packages/tui/src/screens/index.ts
+++ b/packages/tui/src/screens/index.ts
@@ -23,3 +23,6 @@ export { Help } from './Help.js';
 export { Mesh } from './Mesh.js';
 export { Message } from './Message.js';
 export { Scan } from './Scan.js';
+export { Timeline } from './Timeline.js';
+export { Lineage } from './Lineage.js';
+export { Handoff } from './Handoff.js';

--- a/packages/tui/src/state/types.ts
+++ b/packages/tui/src/state/types.ts
@@ -25,7 +25,8 @@ export type Screen =
   | 'home' | 'browse' | 'installed' | 'marketplace' | 'recommend'
   | 'translate' | 'context' | 'memory' | 'team' | 'plugins'
   | 'methodology' | 'plan' | 'workflow' | 'execute' | 'history'
-  | 'sync' | 'settings' | 'help' | 'mesh' | 'message' | 'scan';
+  | 'sync' | 'settings' | 'help' | 'mesh' | 'message' | 'scan'
+  | 'timeline' | 'lineage' | 'handoff';
 
 export const NAV_KEYS: Record<string, Screen> = {
   h: 'home', m: 'marketplace', b: 'browse', w: 'workflow',
@@ -33,6 +34,7 @@ export const NAV_KEYS: Record<string, Screen> = {
   c: 'context', e: 'memory', i: 'installed', s: 'sync',
   a: 'team', p: 'plugins', o: 'methodology', n: 'plan',
   ',': 'settings', '/': 'help', 'g': 'mesh', 'j': 'message', 'z': 'scan',
+  l: 'timeline', v: 'lineage', f: 'handoff',
 } as const;
 
 export const STATUS_BAR_SHORTCUTS = 'b browse  m market  i installed  s sync  / help  q quit';
@@ -83,6 +85,14 @@ export const SIDEBAR_NAV: SidebarSection[] = [
       { key: 'e', label: 'Memory', screen: 'memory' },
       { key: 'g', label: 'Mesh', screen: 'mesh' },
       { key: 'j', label: 'Messages', screen: 'message' },
+    ],
+  },
+  {
+    section: 'Session',
+    items: [
+      { key: 'l', label: 'Timeline', screen: 'timeline' },
+      { key: 'v', label: 'Lineage', screen: 'lineage' },
+      { key: 'f', label: 'Handoff', screen: 'handoff' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Add 3 new TUI screens for session intelligence commands from PR #65: **Timeline** (`l`), **Lineage** (`v`), **Handoff** (`f`)
- New "Session" sidebar section groups all 3 screens
- Fixed negative `selectedIndex` bug on empty lists (caught by CodeRabbit review)
- Extracted nested ternary in Handoff file change labels into `changeTypeLabel()` switch

## Test plan

- [ ] `pnpm build` passes (verified)
- [ ] `pnpm test` passes (verified, 25 tasks)
- [ ] Press `l` in TUI → Timeline screen loads with event stream
- [ ] Press `v` in TUI → Lineage screen shows skill impact graph
- [ ] Press `f` in TUI → Handoff screen shows context transfer document
- [ ] Navigate with j/k on empty lists → no crash (index clamp fix)
- [ ] Sidebar shows new "Session" section with all 3 entries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added Timeline screen to view project events and activity with keyboard-driven navigation
* Added Lineage screen to explore project skills and file change history
* Added Handoff screen to review accomplished tasks, pending items, modified files, and recommendations
* Access new screens via sidebar navigation or keyboard shortcuts (L for Timeline, V for Lineage, F for Handoff)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->