### PR TITLE
fix: update composioHQ repo rename (awesome-claude-code-skills → awesome-claude-skills)

### DIFF
--- a/marketplace/skills.json
+++ b/marketplace/skills.json
@@ -536,28 +536,28 @@
       ]
     },
     {
-      "id": "composioHQ/awesome-claude-code-skills/python-best-practices",
+      "id": "composioHQ/awesome-claude-skills/python-best-practices",
       "name": "Python Best Practices",
       "description": "Python coding standards and patterns",
-      "source": "composioHQ/awesome-claude-code-skills",
+      "source": "composioHQ/awesome-claude-skills",
       "tags": [
         "python"
       ]
     },
     {
-      "id": "composioHQ/awesome-claude-code-skills/rust-patterns",
+      "id": "composioHQ/awesome-claude-skills/rust-patterns",
       "name": "Rust Patterns",
       "description": "Rust memory safety and performance patterns",
-      "source": "composioHQ/awesome-claude-code-skills",
+      "source": "composioHQ/awesome-claude-skills",
       "tags": [
         "rust"
       ]
     },
     {
-      "id": "composioHQ/awesome-claude-code-skills/go-patterns",
+      "id": "composioHQ/awesome-claude-skills/go-patterns",
       "name": "Go Patterns",
       "description": "Go concurrency and idiomatic patterns",
-      "source": "composioHQ/awesome-claude-code-skills",
+      "source": "composioHQ/awesome-claude-skills",
       "tags": [
         "golang",
         "go"

--- a/packages/cli/src/commands/marketplace.ts
+++ b/packages/cli/src/commands/marketplace.ts
@@ -23,7 +23,7 @@ export class MarketplaceCommand extends Command {
       from curated repositories.
 
       Skills are aggregated from multiple sources including:
-      - composioHQ/awesome-claude-code-skills
+      - composioHQ/awesome-claude-skills
       - anthropics/courses
       - User-added custom sources
     `,

--- a/packages/core/src/recommend/fetcher.ts
+++ b/packages/core/src/recommend/fetcher.ts
@@ -12,7 +12,7 @@ import { discoverSkills, extractFrontmatter } from '../skills.js';
 export const KNOWN_SKILL_REPOS = [
   { owner: 'anthropics', repo: 'courses', description: 'Anthropic official courses and skills' },
   { owner: 'vercel-labs', repo: 'ai-sdk-preview-internal-knowledge-base', description: 'Vercel AI SDK skills' },
-  { owner: 'composioHQ', repo: 'awesome-claude-code-skills', description: 'Curated Claude Code skills' },
+  { owner: 'composioHQ', repo: 'awesome-claude-skills', description: 'Curated Claude Code skills' },
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Updated `composioHQ/awesome-claude-code-skills` → `composioHQ/awesome-claude-skills` across 3 files
- The old repo name no longer resolves (404), causing `skillkit recommend --update` to fail

## Changes
- `packages/core/src/recommend/fetcher.ts` — `KNOWN_SKILL_REPOS` array
- `packages/cli/src/commands/marketplace.ts` — usage description
- `marketplace/skills.json` — 6 skill ID/source references

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 1056 tests pass (`pnpm test`)
- [x] Verified new repo URL resolves via `git ls-remote`
- [x] Verified old repo URL returns 404

Closes #72
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated skill marketplace taxonomy references for Python Best Practices, Rust Patterns, and Go Patterns to use unified skills taxonomy.
  * Synchronized marketplace and recommendation system source references to maintain consistency across the platform.
  * Updated related configuration files reflecting the taxonomy changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->