### PR TITLE
feat: live clone progress + sparse checkout for large repos

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -472,7 +472,10 @@ export class InstallCommand extends Command {
           mkdirSync(installDir, { recursive: true });
         }
 
-        const targetPath = join(installDir, skillName);
+        const isStandaloneFile = statSync(sourcePath).isFile();
+        const targetPath = isStandaloneFile
+          ? join(installDir, skillName.endsWith(".md") ? skillName : `${skillName}.md`)
+          : join(installDir, skillName);
 
         if (existsSync(targetPath) && !this.force) {
           if (!this.quiet) {
@@ -497,21 +500,16 @@ export class InstallCommand extends Command {
             rmSync(targetPath, { recursive: true, force: true });
           }
 
-          const isStandaloneFile = statSync(sourcePath).isFile();
-
           if (useSymlink && primaryPath) {
             symlinkSync(primaryPath, targetPath, isStandaloneFile ? "file" : "dir");
           } else {
             if (isStandaloneFile) {
-              const fileDest = targetPath.endsWith(".md") ? targetPath : `${targetPath}.md`;
-              cpSync(sourcePath, fileDest);
+              cpSync(sourcePath, targetPath);
             } else {
               cpSync(sourcePath, targetPath, { recursive: true, dereference: true });
             }
             if (isSymlinkMode && primaryPath === null) {
-              primaryPath = isStandaloneFile
-                ? (targetPath.endsWith(".md") ? targetPath : `${targetPath}.md`)
-                : targetPath;
+              primaryPath = targetPath;
             }
 
             if (!isStandaloneFile) {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -4,6 +4,7 @@ import {
   cpSync,
   rmSync,
   symlinkSync,
+  statSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
@@ -499,7 +500,13 @@ export class InstallCommand extends Command {
           if (useSymlink && primaryPath) {
             symlinkSync(primaryPath, targetPath, "dir");
           } else {
-            cpSync(sourcePath, targetPath, { recursive: true, dereference: true });
+            const isStandaloneFile = statSync(sourcePath).isFile();
+            if (isStandaloneFile) {
+              mkdirSync(targetPath, { recursive: true });
+              cpSync(sourcePath, join(targetPath, "SKILL.md"));
+            } else {
+              cpSync(sourcePath, targetPath, { recursive: true, dereference: true });
+            }
             if (isSymlinkMode && primaryPath === null) {
               primaryPath = targetPath;
             }

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -529,18 +529,16 @@ export class InstallCommand extends Command {
             }
           }
 
-          if (!isStandaloneFile) {
-            const metadata: SkillMetadata = {
-              name: skillName,
-              description: "",
-              source: this.source,
-              sourceType: providerAdapter!.type,
-              subpath: skillName,
-              installedAt: new Date().toISOString(),
-              enabled: true,
-            };
-            saveSkillMetadata(targetPath, metadata);
-          }
+          const metadata: SkillMetadata = {
+            name: skillName,
+            description: "",
+            source: this.source,
+            sourceType: providerAdapter!.type,
+            subpath: skillName,
+            installedAt: new Date().toISOString(),
+            enabled: true,
+          };
+          saveSkillMetadata(targetPath, metadata);
 
           installedAgents.push(agentType);
           s.stop(`Installed ${skillName} to ${adapter.name}${useSymlink ? " (symlink)" : ""}`);

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -235,8 +235,13 @@ export class InstallCommand extends Command {
     }
 
     if (!result) {
-      s.start(`Fetching from ${providerAdapter.name}...`);
-      result = await providerAdapter.clone(this.source, "", { depth: 1 });
+      s.start(`Cloning from ${providerAdapter.name}...`);
+      result = await providerAdapter.clone(this.source, "", {
+        depth: 1,
+        onProgress: (msg) => {
+          s.message(`${providerAdapter!.name} — ${msg}`);
+        },
+      });
 
       if (!result.success || !result.path) {
         s.stop(colors.error(result.error || "Failed to fetch source"));

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -472,7 +472,15 @@ export class InstallCommand extends Command {
           mkdirSync(installDir, { recursive: true });
         }
 
-        const isStandaloneFile = statSync(sourcePath).isFile();
+        let isStandaloneFile: boolean;
+        try {
+          isStandaloneFile = statSync(sourcePath).isFile();
+        } catch {
+          if (!this.quiet) {
+            warn(`Skipping ${skillName} for ${adapter.name} (source not accessible)`);
+          }
+          continue;
+        }
         const targetPath = isStandaloneFile
           ? join(installDir, skillName.endsWith(".md") ? skillName : `${skillName}.md`)
           : join(installDir, skillName);

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -497,45 +497,52 @@ export class InstallCommand extends Command {
             rmSync(targetPath, { recursive: true, force: true });
           }
 
+          const isStandaloneFile = statSync(sourcePath).isFile();
+
           if (useSymlink && primaryPath) {
-            symlinkSync(primaryPath, targetPath, "dir");
+            symlinkSync(primaryPath, targetPath, isStandaloneFile ? "file" : "dir");
           } else {
-            const isStandaloneFile = statSync(sourcePath).isFile();
             if (isStandaloneFile) {
-              mkdirSync(targetPath, { recursive: true });
-              cpSync(sourcePath, join(targetPath, "SKILL.md"));
+              const fileDest = targetPath.endsWith(".md") ? targetPath : `${targetPath}.md`;
+              cpSync(sourcePath, fileDest);
             } else {
               cpSync(sourcePath, targetPath, { recursive: true, dereference: true });
             }
             if (isSymlinkMode && primaryPath === null) {
-              primaryPath = targetPath;
+              primaryPath = isStandaloneFile
+                ? (targetPath.endsWith(".md") ? targetPath : `${targetPath}.md`)
+                : targetPath;
             }
 
-            const packageJsonPath = join(targetPath, "package.json");
-            if (existsSync(packageJsonPath)) {
-              s.stop(`Installed ${skillName} to ${adapter.name}`);
-              s.start(`Installing npm dependencies for ${skillName}...`);
-              try {
-                await execFileAsync("npm", ["install", "--omit=dev"], { cwd: targetPath });
-                s.stop(`Installed dependencies for ${skillName}`);
-              } catch {
-                s.stop(colors.warning(`Dependencies failed for ${skillName}`));
-                console.log(colors.muted("Run manually: npm install in " + targetPath));
+            if (!isStandaloneFile) {
+              const packageJsonPath = join(targetPath, "package.json");
+              if (existsSync(packageJsonPath)) {
+                s.stop(`Installed ${skillName} to ${adapter.name}`);
+                s.start(`Installing npm dependencies for ${skillName}...`);
+                try {
+                  await execFileAsync("npm", ["install", "--omit=dev"], { cwd: targetPath });
+                  s.stop(`Installed dependencies for ${skillName}`);
+                } catch {
+                  s.stop(colors.warning(`Dependencies failed for ${skillName}`));
+                  console.log(colors.muted("Run manually: npm install in " + targetPath));
+                }
+                s.start(`Finishing ${skillName} installation...`);
               }
-              s.start(`Finishing ${skillName} installation...`);
             }
           }
 
-          const metadata: SkillMetadata = {
-            name: skillName,
-            description: "",
-            source: this.source,
-            sourceType: providerAdapter!.type,
-            subpath: skillName,
-            installedAt: new Date().toISOString(),
-            enabled: true,
-          };
-          saveSkillMetadata(targetPath, metadata);
+          if (!isStandaloneFile) {
+            const metadata: SkillMetadata = {
+              name: skillName,
+              description: "",
+              source: this.source,
+              sourceType: providerAdapter!.type,
+              subpath: skillName,
+              installedAt: new Date().toISOString(),
+              enabled: true,
+            };
+            saveSkillMetadata(targetPath, metadata);
+          }
 
           installedAgents.push(agentType);
           s.stop(`Installed ${skillName} to ${adapter.name}${useSymlink ? " (symlink)" : ""}`);

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -134,7 +134,7 @@ export class InstallCommand extends Command {
     const s = spinner();
 
     try {
-      if (isInteractive && !this.quiet) {
+      if (process.stdin.isTTY && !this.quiet) {
         welcome();
       }
 

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -48,7 +48,7 @@ export class RemoveCommand extends Command {
       if (this.source) {
         skillsToRemove = allSkills.filter((s) => {
           const meta = loadMetadata(s.path);
-          return meta && meta.source.includes(this.source!);
+          return meta?.source?.includes(this.source!) ?? false;
         }).map((s) => ({ name: s.name, path: s.path }));
         if (skillsToRemove.length === 0) {
           warn(`No skills found from source: ${this.source}`);

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -1,5 +1,5 @@
 import { existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { colors, warn, success, error } from '../onboarding/index.js';
 import { Command, Option } from 'clipanion';
 import { findSkill, findAllSkills, loadMetadata, AgentsMdParser, AgentsMdGenerator } from '@skillkit/core';
@@ -84,6 +84,10 @@ export class RemoveCommand extends Command {
 
       try {
         rmSync(skillPath, { recursive: true, force: true });
+        if (skillPath.endsWith('.md')) {
+          const metaSibling = join(dirname(skillPath), `.${basename(skillPath, '.md')}.skillkit.json`);
+          if (existsSync(metaSibling)) rmSync(metaSibling);
+        }
         success(`Removed: ${skillName}`);
         removed++;
       } catch (err) {

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -2,7 +2,7 @@ import { existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { colors, warn, success, error } from '../onboarding/index.js';
 import { Command, Option } from 'clipanion';
-import { findSkill, AgentsMdParser, AgentsMdGenerator } from '@skillkit/core';
+import { findSkill, findAllSkills, loadMetadata, AgentsMdParser, AgentsMdGenerator } from '@skillkit/core';
 import { getSearchDirs } from '../helpers.js';
 
 export class RemoveCommand extends Command {
@@ -13,11 +13,21 @@ export class RemoveCommand extends Command {
     examples: [
       ['Remove a skill', '$0 remove pdf'],
       ['Remove multiple skills', '$0 remove pdf xlsx docx'],
-      ['Force removal without confirmation', '$0 remove pdf --force'],
+      ['Remove all skills from a source', '$0 remove --source iii-hq/iii'],
+      ['Remove all installed skills', '$0 remove --all'],
+      ['Force removal without confirmation', '$0 remove --all --force'],
     ],
   });
 
-  skills = Option.Rest({ required: 1 });
+  skills = Option.Rest({ required: 0 });
+
+  all = Option.Boolean('--all,-a', false, {
+    description: 'Remove all installed skills',
+  });
+
+  source = Option.String('--source,-s', {
+    description: 'Remove all skills installed from this source (e.g. iii-hq/iii)',
+  });
 
   force = Option.Boolean('--force,-f', false, {
     description: 'Skip confirmation',
@@ -25,24 +35,55 @@ export class RemoveCommand extends Command {
 
   async execute(): Promise<number> {
     const searchDirs = getSearchDirs();
+
+    if (!this.all && !this.source && this.skills.length === 0) {
+      error('Provide skill names, --source, or --all');
+      return 1;
+    }
+
+    let skillsToRemove: Array<{ name: string; path: string }> = [];
+
+    if (this.all || this.source) {
+      const allSkills = findAllSkills(searchDirs);
+      if (this.source) {
+        skillsToRemove = allSkills.filter((s) => {
+          const meta = loadMetadata(s.path);
+          return meta && meta.source.includes(this.source!);
+        }).map((s) => ({ name: s.name, path: s.path }));
+        if (skillsToRemove.length === 0) {
+          warn(`No skills found from source: ${this.source}`);
+          return 0;
+        }
+      } else {
+        skillsToRemove = allSkills.map((s) => ({ name: s.name, path: s.path }));
+        if (skillsToRemove.length === 0) {
+          warn('No installed skills found');
+          return 0;
+        }
+      }
+      console.log(colors.muted(`Found ${skillsToRemove.length} skill(s) to remove`));
+    } else {
+      for (const skillName of this.skills) {
+        const skill = findSkill(skillName, searchDirs);
+        if (!skill) {
+          warn(`Skill not found: ${skillName}`);
+          continue;
+        }
+        skillsToRemove.push({ name: skill.name, path: skill.path });
+      }
+    }
+
     let removed = 0;
     let failed = 0;
 
-    for (const skillName of this.skills) {
-      const skill = findSkill(skillName, searchDirs);
-
-      if (!skill) {
-        warn(`Skill not found: ${skillName}`);
-        continue;
-      }
-
-      if (!existsSync(skill.path)) {
-        warn(`Path not found: ${skill.path}`);
+    for (const { name: skillName, path: skillPath } of skillsToRemove) {
+      if (!existsSync(skillPath)) {
+        warn(`Path not found: ${skillPath}`);
         continue;
       }
 
       try {
-        rmSync(skill.path, { recursive: true, force: true });
+        rmSync(skillPath, { recursive: true, force: true });
         success(`Removed: ${skillName}`);
         removed++;
       } catch (err) {

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -8,7 +8,7 @@ import {
   loadSkillMetadata as coreLoadSkillMetadata,
   saveSkillMetadata as coreSaveSkillMetadata,
 } from "@skillkit/core";
-import { getAdapter, detectAgent } from "@skillkit/agents";
+import { getAdapter, detectAgent, getAllAdapters } from "@skillkit/agents";
 import type { AgentType, AgentAdapterInfo } from "@skillkit/core";
 
 // Re-export metadata functions directly (they don't need adapter bridging)
@@ -16,15 +16,25 @@ export const loadSkillMetadata = coreLoadSkillMetadata;
 export const saveSkillMetadata = coreSaveSkillMetadata;
 
 export function getSearchDirs(agentType?: AgentType): string[] {
-  const type = agentType || loadConfig().agent;
-  const adapter = getAdapter(type);
-  const adapterInfo: AgentAdapterInfo = {
-    type: adapter.type,
-    name: adapter.name,
-    skillsDir: adapter.skillsDir,
-    configFile: adapter.configFile,
-  };
-  return coreGetSearchDirs(adapterInfo);
+  const dirs = new Set<string>();
+
+  const adapters = agentType
+    ? [getAdapter(agentType)]
+    : getAllAdapters();
+
+  for (const adapter of adapters) {
+    const info: AgentAdapterInfo = {
+      type: adapter.type,
+      name: adapter.name,
+      skillsDir: adapter.skillsDir,
+      configFile: adapter.configFile,
+    };
+    for (const dir of coreGetSearchDirs(info)) {
+      dirs.add(dir);
+    }
+  }
+
+  return [...dirs];
 }
 
 export function getInstallDir(global = false, agentType?: AgentType): string {

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -1,4 +1,3 @@
-// Re-export commonly used functions with proper adapters
 import {
   loadConfig,
   getSearchDirs as coreGetSearchDirs,
@@ -11,66 +10,37 @@ import {
 import { getAdapter, detectAgent, getAllAdapters } from "@skillkit/agents";
 import type { AgentType, AgentAdapterInfo } from "@skillkit/core";
 
-// Re-export metadata functions directly (they don't need adapter bridging)
 export const loadSkillMetadata = coreLoadSkillMetadata;
 export const saveSkillMetadata = coreSaveSkillMetadata;
 
+function toAdapterInfo(adapter: { type: AgentType; name: string; skillsDir: string; configFile: string }): AgentAdapterInfo {
+  return { type: adapter.type, name: adapter.name, skillsDir: adapter.skillsDir, configFile: adapter.configFile };
+}
+
 export function getSearchDirs(agentType?: AgentType): string[] {
   const dirs = new Set<string>();
-
-  const adapters = agentType
-    ? [getAdapter(agentType)]
-    : getAllAdapters();
-
+  const adapters = agentType ? [getAdapter(agentType)] : getAllAdapters();
   for (const adapter of adapters) {
-    const info: AgentAdapterInfo = {
-      type: adapter.type,
-      name: adapter.name,
-      skillsDir: adapter.skillsDir,
-      configFile: adapter.configFile,
-    };
-    for (const dir of coreGetSearchDirs(info)) {
+    for (const dir of coreGetSearchDirs(toAdapterInfo(adapter))) {
       dirs.add(dir);
     }
   }
-
   return [...dirs];
 }
 
 export function getInstallDir(global = false, agentType?: AgentType): string {
   const type = agentType || loadConfig().agent;
-  const adapter = getAdapter(type);
-  const adapterInfo: AgentAdapterInfo = {
-    type: adapter.type,
-    name: adapter.name,
-    skillsDir: adapter.skillsDir,
-    configFile: adapter.configFile,
-  };
-  return coreGetInstallDir(adapterInfo, global);
+  return coreGetInstallDir(toAdapterInfo(getAdapter(type)), global);
 }
 
 export function getAgentConfigPath(agentType?: AgentType): string {
   const type = agentType || loadConfig().agent;
-  const adapter = getAdapter(type);
-  const adapterInfo: AgentAdapterInfo = {
-    type: adapter.type,
-    name: adapter.name,
-    skillsDir: adapter.skillsDir,
-    configFile: adapter.configFile,
-  };
-  return coreGetAgentConfigPath(adapterInfo);
+  return coreGetAgentConfigPath(toAdapterInfo(getAdapter(type)));
 }
 
 export async function initProject(agentType?: AgentType): Promise<void> {
   const type = agentType || (await detectAgent());
-  const adapter = getAdapter(type);
-  const adapterInfo: AgentAdapterInfo = {
-    type: adapter.type,
-    name: adapter.name,
-    skillsDir: adapter.skillsDir,
-    configFile: adapter.configFile,
-  };
-  return coreInitProject(type, adapterInfo);
+  return coreInitProject(type, toAdapterInfo(getAdapter(type)));
 }
 
 export function formatCount(count: number): string {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,11 +1,18 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { SkillkitConfig, type AgentType, type SkillMetadata, type AgentAdapterInfo } from './types.js';
 
 const CONFIG_FILE = 'skillkit.yaml';
 const METADATA_FILE = '.skillkit.json';
+
+function metadataPathFor(skillPath: string): string {
+  if (skillPath.endsWith('.md') && existsSync(skillPath) && statSync(skillPath).isFile()) {
+    return join(dirname(skillPath), `.${basename(skillPath, '.md')}.skillkit.json`);
+  }
+  return join(skillPath, METADATA_FILE);
+}
 
 export function getProjectConfigPath(): string {
   return join(process.cwd(), CONFIG_FILE);
@@ -110,12 +117,12 @@ export function getAgentConfigPath(adapter: AgentAdapterInfo): string {
 }
 
 export function saveSkillMetadata(skillPath: string, metadata: SkillMetadata): void {
-  const metadataPath = join(skillPath, METADATA_FILE);
+  const metadataPath = metadataPathFor(skillPath);
   writeFileSync(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8');
 }
 
 export function loadSkillMetadata(skillPath: string): SkillMetadata | null {
-  const metadataPath = join(skillPath, METADATA_FILE);
+  const metadataPath = metadataPathFor(skillPath);
 
   if (!existsSync(metadataPath)) {
     return null;

--- a/packages/core/src/providers/base.ts
+++ b/packages/core/src/providers/base.ts
@@ -1,4 +1,7 @@
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
 import type { GitProvider, CloneResult } from '../types.js';
+import { SKILL_DISCOVERY_PATHS } from '../skills.js';
 
 export interface GitProviderAdapter {
   readonly type: GitProvider;
@@ -16,6 +19,108 @@ export interface CloneOptions {
   depth?: number;
   branch?: string;
   ssh?: boolean;
+  onProgress?: (message: string) => void;
+}
+
+function parseGitProgress(text: string): string | null {
+  const lines = text.split(/[\r\n]+/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    const pctMatch = line.match(/([\w\s]+):\s*(\d+)%\s*\((\d+)\/(\d+)\)(?:,\s*(.+?))?(?:\s*$|\s*\r)/);
+    if (pctMatch) {
+      const phase = pctMatch[1].replace(/^remote:\s*/, '').trim();
+      const pct = pctMatch[2];
+      const size = pctMatch[5]?.replace(/,?\s*done\.?$/, '').trim();
+      return size ? `${phase} ${pct}% ${size}` : `${phase} ${pct}%`;
+    }
+
+    const remoteMatch = line.match(/remote:\s*([\w\s]+):\s*(\d+)%/);
+    if (remoteMatch) {
+      return `${remoteMatch[1].trim()} ${remoteMatch[2]}%`;
+    }
+
+    const remoteDone = line.match(/remote:\s*([\w\s]+):\s*\d+.*done/);
+    if (remoteDone) {
+      return `${remoteDone[1].trim()}`;
+    }
+  }
+  return null;
+}
+
+function spawnGit(args: string[]): Promise<void>;
+function spawnGit(args: string[], onProgress: (msg: string) => void): Promise<void>;
+function spawnGit(args: string[], onProgress?: (msg: string) => void): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const proc = spawn('git', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderr = '';
+
+    proc.stderr?.on('data', (data: Buffer) => {
+      const text = data.toString();
+      stderr += text;
+      if (onProgress) {
+        const msg = parseGitProgress(text);
+        if (msg) onProgress(msg);
+      }
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(stderr.slice(-500)));
+    });
+
+    proc.on('error', reject);
+  });
+}
+
+export async function cloneRepo(
+  cloneUrl: string,
+  tempDir: string,
+  options: CloneOptions = {},
+): Promise<void> {
+  const args = ['clone', '--progress', '--single-branch', '--no-tags'];
+
+  if (options.depth) {
+    args.push('--depth', String(options.depth));
+  }
+  if (options.branch) {
+    args.push('--branch', options.branch);
+  }
+
+  const tryPartialClone = !options.branch;
+
+  if (tryPartialClone) {
+    const partialArgs = [...args, '--filter=blob:none', '--no-checkout', cloneUrl, tempDir];
+
+    try {
+      await spawnGit(partialArgs, options.onProgress ?? (() => {}));
+
+      execFileSync('git', ['-C', tempDir, 'sparse-checkout', 'init', '--cone'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const sparsePaths = SKILL_DISCOVERY_PATHS.filter((p) => !p.includes('/'));
+      const deepPaths = SKILL_DISCOVERY_PATHS.filter((p) => p.includes('/'));
+      execFileSync(
+        'git',
+        ['-C', tempDir, 'sparse-checkout', 'set', ...sparsePaths, ...deepPaths],
+        { stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+
+      options.onProgress?.('Checking out files');
+      await spawnGit(['-C', tempDir, 'checkout'], options.onProgress ?? (() => {}));
+
+      return;
+    } catch {
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
+  }
+
+  args.push(cloneUrl, tempDir);
+  await spawnGit(args, options.onProgress ?? (() => {}));
 }
 
 export function parseShorthand(source: string): { owner: string; repo: string; subpath?: string } | null {

--- a/packages/core/src/providers/base.ts
+++ b/packages/core/src/providers/base.ts
@@ -19,6 +19,7 @@ export interface CloneOptions {
   depth?: number;
   branch?: string;
   ssh?: boolean;
+  subpath?: string;
   onProgress?: (message: string) => void;
 }
 
@@ -100,11 +101,16 @@ export async function cloneRepo(
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
-      const sparsePaths = SKILL_DISCOVERY_PATHS.filter((p) => !p.includes('/'));
-      const deepPaths = SKILL_DISCOVERY_PATHS.filter((p) => p.includes('/'));
+      const sparsePaths = [...SKILL_DISCOVERY_PATHS];
+      if (options.subpath) {
+        sparsePaths.push(options.subpath);
+        for (const dp of SKILL_DISCOVERY_PATHS) {
+          sparsePaths.push(`${options.subpath}/${dp}`);
+        }
+      }
       execFileSync(
         'git',
-        ['-C', tempDir, 'sparse-checkout', 'set', ...sparsePaths, ...deepPaths],
+        ['-C', tempDir, 'sparse-checkout', 'set', ...sparsePaths],
         { stdio: ['pipe', 'pipe', 'pipe'] },
       );
 

--- a/packages/core/src/providers/base.ts
+++ b/packages/core/src/providers/base.ts
@@ -50,8 +50,6 @@ function parseGitProgress(text: string): string | null {
   return null;
 }
 
-function spawnGit(args: string[]): Promise<void>;
-function spawnGit(args: string[], onProgress: (msg: string) => void): Promise<void>;
 function spawnGit(args: string[], onProgress?: (msg: string) => void): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const proc = spawn('git', args, { stdio: ['pipe', 'ignore', 'pipe'] });
@@ -96,7 +94,7 @@ export async function cloneRepo(
 
     let partialCloneOk = false;
     try {
-      await spawnGit(partialArgs, options.onProgress ?? (() => {}));
+      await spawnGit(partialArgs, options.onProgress);
       partialCloneOk = true;
     } catch {
       options.onProgress?.('Partial clone unsupported, falling back to full clone');
@@ -124,14 +122,14 @@ export async function cloneRepo(
       );
 
       options.onProgress?.('Checking out files');
-      await spawnGit(['-C', tempDir, 'checkout'], options.onProgress ?? (() => {}));
+      await spawnGit(['-C', tempDir, 'checkout'], options.onProgress);
 
       return;
     }
   }
 
   args.push(cloneUrl, tempDir);
-  await spawnGit(args, options.onProgress ?? (() => {}));
+  await spawnGit(args, options.onProgress);
 }
 
 export function parseShorthand(source: string): { owner: string; repo: string; subpath?: string } | null {

--- a/packages/core/src/providers/base.ts
+++ b/packages/core/src/providers/base.ts
@@ -54,7 +54,7 @@ function spawnGit(args: string[]): Promise<void>;
 function spawnGit(args: string[], onProgress: (msg: string) => void): Promise<void>;
 function spawnGit(args: string[], onProgress?: (msg: string) => void): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const proc = spawn('git', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    const proc = spawn('git', args, { stdio: ['pipe', 'ignore', 'pipe'] });
     let stderr = '';
 
     proc.stderr?.on('data', (data: Buffer) => {
@@ -118,7 +118,8 @@ export async function cloneRepo(
       await spawnGit(['-C', tempDir, 'checkout'], options.onProgress ?? (() => {}));
 
       return;
-    } catch {
+    } catch (err) {
+      options.onProgress?.(`Partial clone unsupported, falling back to full clone`);
       if (existsSync(tempDir)) {
         rmSync(tempDir, { recursive: true, force: true });
       }

--- a/packages/core/src/providers/base.ts
+++ b/packages/core/src/providers/base.ts
@@ -59,7 +59,7 @@ function spawnGit(args: string[], onProgress?: (msg: string) => void): Promise<v
 
     proc.stderr?.on('data', (data: Buffer) => {
       const text = data.toString();
-      stderr += text;
+      stderr = (stderr + text).slice(-4096);
       if (onProgress) {
         const msg = parseGitProgress(text);
         if (msg) onProgress(msg);
@@ -94,9 +94,18 @@ export async function cloneRepo(
   if (tryPartialClone) {
     const partialArgs = [...args, '--filter=blob:none', '--no-checkout', cloneUrl, tempDir];
 
+    let partialCloneOk = false;
     try {
       await spawnGit(partialArgs, options.onProgress ?? (() => {}));
+      partialCloneOk = true;
+    } catch {
+      options.onProgress?.('Partial clone unsupported, falling back to full clone');
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
 
+    if (partialCloneOk) {
       execFileSync('git', ['-C', tempDir, 'sparse-checkout', 'init', '--cone'], {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
@@ -110,7 +119,7 @@ export async function cloneRepo(
       }
       execFileSync(
         'git',
-        ['-C', tempDir, 'sparse-checkout', 'set', ...sparsePaths],
+        ['-C', tempDir, 'sparse-checkout', 'set', '--', ...sparsePaths],
         { stdio: ['pipe', 'pipe', 'pipe'] },
       );
 
@@ -118,11 +127,6 @@ export async function cloneRepo(
       await spawnGit(['-C', tempDir, 'checkout'], options.onProgress ?? (() => {}));
 
       return;
-    } catch (err) {
-      options.onProgress?.(`Partial clone unsupported, falling back to full clone`);
-      if (existsSync(tempDir)) {
-        rmSync(tempDir, { recursive: true, force: true });
-      }
     }
   }
 

--- a/packages/core/src/providers/base.ts
+++ b/packages/core/src/providers/base.ts
@@ -104,27 +104,34 @@ export async function cloneRepo(
     }
 
     if (partialCloneOk) {
-      execFileSync('git', ['-C', tempDir, 'sparse-checkout', 'init', '--cone'], {
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+      try {
+        execFileSync('git', ['-C', tempDir, 'sparse-checkout', 'init', '--cone'], {
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
 
-      const sparsePaths = [...SKILL_DISCOVERY_PATHS];
-      if (options.subpath) {
-        sparsePaths.push(options.subpath);
-        for (const dp of SKILL_DISCOVERY_PATHS) {
-          sparsePaths.push(`${options.subpath}/${dp}`);
+        const sparsePaths = [...SKILL_DISCOVERY_PATHS];
+        if (options.subpath) {
+          sparsePaths.push(options.subpath);
+          for (const dp of SKILL_DISCOVERY_PATHS) {
+            sparsePaths.push(`${options.subpath}/${dp}`);
+          }
+        }
+        execFileSync(
+          'git',
+          ['-C', tempDir, 'sparse-checkout', 'set', '--', ...sparsePaths],
+          { stdio: ['pipe', 'pipe', 'pipe'] },
+        );
+
+        options.onProgress?.('Checking out files');
+        await spawnGit(['-C', tempDir, 'checkout'], options.onProgress);
+
+        return;
+      } catch {
+        options.onProgress?.('Sparse checkout failed, falling back to full clone');
+        if (existsSync(tempDir)) {
+          rmSync(tempDir, { recursive: true, force: true });
         }
       }
-      execFileSync(
-        'git',
-        ['-C', tempDir, 'sparse-checkout', 'set', '--', ...sparsePaths],
-        { stdio: ['pipe', 'pipe', 'pipe'] },
-      );
-
-      options.onProgress?.('Checking out files');
-      await spawnGit(['-C', tempDir, 'checkout'], options.onProgress);
-
-      return;
     }
   }
 

--- a/packages/core/src/providers/bitbucket.ts
+++ b/packages/core/src/providers/bitbucket.ts
@@ -75,7 +75,7 @@ export class BitbucketProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-${randomUUID()}`);
 
     try {
-      await cloneRepo(cloneUrl, tempDir, options);
+      await cloneRepo(cloneUrl, tempDir, { ...options, subpath });
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
       const skills = discoverSkills(searchDir);

--- a/packages/core/src/providers/bitbucket.ts
+++ b/packages/core/src/providers/bitbucket.ts
@@ -1,10 +1,9 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { GitProviderAdapter, CloneOptions } from "./base.js";
-import { parseShorthand } from "./base.js";
+import { parseShorthand, cloneRepo } from "./base.js";
 import type { GitProvider, CloneResult } from "../types.js";
 import { discoverSkills } from "../skills.js";
 
@@ -76,19 +75,7 @@ export class BitbucketProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-${randomUUID()}`);
 
     try {
-      const args = ["clone"];
-      if (options.depth) {
-        args.push("--depth", String(options.depth));
-      }
-      if (options.branch) {
-        args.push("--branch", options.branch);
-      }
-      args.push(cloneUrl, tempDir);
-
-      execFileSync("git", args, {
-        stdio: ["pipe", "pipe", "pipe"],
-        encoding: "utf-8",
-      });
+      await cloneRepo(cloneUrl, tempDir, options);
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
       const skills = discoverSkills(searchDir);

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -68,7 +68,7 @@ export class GitHubProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-${randomUUID()}`);
 
     try {
-      await cloneRepo(cloneUrl, tempDir, options);
+      await cloneRepo(cloneUrl, tempDir, { ...options, subpath });
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
       const skills = discoverSkills(searchDir);

--- a/packages/core/src/providers/github.ts
+++ b/packages/core/src/providers/github.ts
@@ -1,10 +1,9 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { GitProviderAdapter, CloneOptions } from "./base.js";
-import { parseShorthand, isGitUrl } from "./base.js";
+import { parseShorthand, isGitUrl, cloneRepo } from "./base.js";
 import type { GitProvider, CloneResult } from "../types.js";
 import { discoverSkills } from "../skills.js";
 
@@ -69,19 +68,7 @@ export class GitHubProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-${randomUUID()}`);
 
     try {
-      const args = ["clone"];
-      if (options.depth) {
-        args.push("--depth", String(options.depth));
-      }
-      if (options.branch) {
-        args.push("--branch", options.branch);
-      }
-      args.push(cloneUrl, tempDir);
-
-      execFileSync("git", args, {
-        stdio: ["pipe", "pipe", "pipe"],
-        encoding: "utf-8",
-      });
+      await cloneRepo(cloneUrl, tempDir, options);
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
       const skills = discoverSkills(searchDir);

--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -1,10 +1,9 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { GitProviderAdapter, CloneOptions } from "./base.js";
-import { parseShorthand } from "./base.js";
+import { parseShorthand, cloneRepo } from "./base.js";
 import type { GitProvider, CloneResult } from "../types.js";
 import { discoverSkills } from "../skills.js";
 
@@ -74,19 +73,7 @@ export class GitLabProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-${randomUUID()}`);
 
     try {
-      const args = ["clone"];
-      if (options.depth) {
-        args.push("--depth", String(options.depth));
-      }
-      if (options.branch) {
-        args.push("--branch", options.branch);
-      }
-      args.push(cloneUrl, tempDir);
-
-      execFileSync("git", args, {
-        stdio: ["pipe", "pipe", "pipe"],
-        encoding: "utf-8",
-      });
+      await cloneRepo(cloneUrl, tempDir, options);
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
       const skills = discoverSkills(searchDir);

--- a/packages/core/src/providers/gitlab.ts
+++ b/packages/core/src/providers/gitlab.ts
@@ -73,7 +73,7 @@ export class GitLabProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-${randomUUID()}`);
 
     try {
-      await cloneRepo(cloneUrl, tempDir, options);
+      await cloneRepo(cloneUrl, tempDir, { ...options, subpath });
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
       const skills = discoverSkills(searchDir);

--- a/packages/core/src/providers/skills-sh.ts
+++ b/packages/core/src/providers/skills-sh.ts
@@ -65,7 +65,7 @@ export class SkillsShProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-skillssh-${randomUUID()}`);
 
     try {
-      await cloneRepo(cloneUrl, tempDir, options);
+      await cloneRepo(cloneUrl, tempDir, { ...options, subpath });
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
 

--- a/packages/core/src/providers/skills-sh.ts
+++ b/packages/core/src/providers/skills-sh.ts
@@ -1,9 +1,9 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { join, basename, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { GitProviderAdapter, CloneOptions } from "./base.js";
+import { cloneRepo } from "./base.js";
 import type { GitProvider, CloneResult } from "../types.js";
 import { discoverSkills } from "../skills.js";
 
@@ -65,19 +65,7 @@ export class SkillsShProvider implements GitProviderAdapter {
     const tempDir = join(tmpdir(), `skillkit-skillssh-${randomUUID()}`);
 
     try {
-      const args = ["clone"];
-      if (options.depth) {
-        args.push("--depth", String(options.depth));
-      }
-      if (options.branch) {
-        args.push("--branch", options.branch);
-      }
-      args.push(cloneUrl, tempDir);
-
-      execFileSync("git", args, {
-        stdio: ["pipe", "pipe", "pipe"],
-        encoding: "utf-8",
-      });
+      await cloneRepo(cloneUrl, tempDir, options);
 
       const searchDir = subpath ? join(tempDir, subpath) : tempDir;
 

--- a/packages/core/src/scanner/analyzers/static.ts
+++ b/packages/core/src/scanner/analyzers/static.ts
@@ -64,25 +64,27 @@ function stripMarkdownCodeAndFrontmatter(content: string): string {
   let inFrontmatter = false;
   let frontmatterDone = false;
 
+  if (lines.length > 0 && /^---\s*$/.test(lines[0].trim())) {
+    const hasCloser = lines.slice(1).some((l) => /^---\s*$/.test(l.trim()));
+    if (hasCloser) {
+      inFrontmatter = true;
+    }
+  }
+
   return lines.map((line, i) => {
     const trimmed = line.trim();
 
-    if (!frontmatterDone && /^---\s*$/.test(trimmed)) {
-      if (!inFrontmatter && i < 2) {
-        inFrontmatter = true;
-        return '';
-      }
-      if (inFrontmatter) {
+    if (inFrontmatter && !frontmatterDone) {
+      if (i > 0 && /^---\s*$/.test(trimmed)) {
         inFrontmatter = false;
         frontmatterDone = true;
-        return '';
       }
+      return '';
     }
-    if (inFrontmatter) return '';
 
     if (/^(`{3,}|~{3,})/.test(trimmed)) {
       inCodeBlock = !inCodeBlock;
-      return '';
+      return line;
     }
     if (inCodeBlock) return '';
 

--- a/packages/core/src/scanner/analyzers/static.ts
+++ b/packages/core/src/scanner/analyzers/static.ts
@@ -58,6 +58,38 @@ function ruleMatchesFileType(rule: SecurityRule, fileType: string | undefined): 
   return rule.fileTypes.includes(fileType);
 }
 
+function stripMarkdownCodeAndFrontmatter(content: string): string {
+  const lines = content.split('\n');
+  let inCodeBlock = false;
+  let inFrontmatter = false;
+  let frontmatterDone = false;
+
+  return lines.map((line, i) => {
+    const trimmed = line.trim();
+
+    if (!frontmatterDone && /^---\s*$/.test(trimmed)) {
+      if (!inFrontmatter && i < 2) {
+        inFrontmatter = true;
+        return '';
+      }
+      if (inFrontmatter) {
+        inFrontmatter = false;
+        frontmatterDone = true;
+        return '';
+      }
+    }
+    if (inFrontmatter) return '';
+
+    if (/^(`{3,}|~{3,})/.test(trimmed)) {
+      inCodeBlock = !inCodeBlock;
+      return '';
+    }
+    if (inCodeBlock) return '';
+
+    return line;
+  }).join('\n');
+}
+
 function matchesExcludePatterns(line: string, rule: SecurityRule): boolean {
   if (!rule.excludePatterns) return false;
   return rule.excludePatterns.some((p) => p.test(line));
@@ -93,6 +125,10 @@ export class StaticAnalyzer implements Analyzer {
         content = await readFile(file, 'utf-8');
       } catch {
         continue;
+      }
+
+      if (fileType === 'markdown') {
+        content = stripMarkdownCodeAndFrontmatter(content);
       }
 
       const lines = content.split('\n');

--- a/packages/core/src/scanner/analyzers/static.ts
+++ b/packages/core/src/scanner/analyzers/static.ts
@@ -60,7 +60,7 @@ function ruleMatchesFileType(rule: SecurityRule, fileType: string | undefined): 
 
 function stripMarkdownCodeAndFrontmatter(content: string): string {
   const lines = content.split('\n');
-  let inCodeBlock = false;
+  let fenceDelimiter: string | null = null;
   let inFrontmatter = false;
   let frontmatterDone = false;
 
@@ -82,11 +82,18 @@ function stripMarkdownCodeAndFrontmatter(content: string): string {
       return '';
     }
 
-    if (/^(`{3,}|~{3,})/.test(trimmed)) {
-      inCodeBlock = !inCodeBlock;
-      return line;
+    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      if (fenceDelimiter === null) {
+        fenceDelimiter = char;
+        return line;
+      } else if (char === fenceDelimiter) {
+        fenceDelimiter = null;
+        return line;
+      }
     }
-    if (inCodeBlock) return '';
+    if (fenceDelimiter !== null) return '';
 
     return line;
   }).join('\n');

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, basename, resolve, sep } from 'node:path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, basename, dirname, resolve, sep } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { SkillFrontmatter, SkillMetadata, type Skill, type SkillLocation } from './types.js';
 
@@ -274,7 +274,10 @@ export function extractField(content: string, field: string): string | null {
 }
 
 export function loadMetadata(skillPath: string): SkillMetadata | null {
-  const metadataPath = join(skillPath, '.skillkit.json');
+  const isFile = skillPath.endsWith('.md') && existsSync(skillPath) && statSync(skillPath).isFile();
+  const metadataPath = isFile
+    ? join(dirname(skillPath), `.${basename(skillPath, '.md')}.skillkit.json`)
+    : join(skillPath, '.skillkit.json');
 
   if (!existsSync(metadataPath)) {
     return null;

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -314,11 +314,12 @@ export function findSkill(name: string, searchDirs: string[]): Skill | null {
   for (const dir of searchDirs) {
     if (!existsSync(dir)) continue;
 
-    const location: SkillLocation = dir.includes(process.cwd()) ? 'project' : 'global';
+    const location: SkillLocation = isPathInside(dir, process.cwd()) ? 'project' : 'global';
 
     const skillPath = join(dir, name);
     if (existsSync(skillPath)) {
-      return parseSkill(skillPath, location);
+      const skill = parseSkill(skillPath, location);
+      if (skill) return skill;
     }
 
     const mdPath = join(dir, name.endsWith('.md') ? name : `${name}.md`);
@@ -337,7 +338,7 @@ export function findAllSkills(searchDirs: string[]): Skill[] {
   for (const dir of searchDirs) {
     if (!existsSync(dir)) continue;
 
-    const location: SkillLocation = dir.includes(process.cwd()) ? 'project' : 'global';
+    const location: SkillLocation = isPathInside(dir, process.cwd()) ? 'project' : 'global';
     const discovered = discoverSkills(dir);
 
     for (const skill of discovered) {

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -311,10 +311,16 @@ export function findSkill(name: string, searchDirs: string[]): Skill | null {
   for (const dir of searchDirs) {
     if (!existsSync(dir)) continue;
 
+    const location: SkillLocation = dir.includes(process.cwd()) ? 'project' : 'global';
+
     const skillPath = join(dir, name);
     if (existsSync(skillPath)) {
-      const location: SkillLocation = dir.includes(process.cwd()) ? 'project' : 'global';
       return parseSkill(skillPath, location);
+    }
+
+    const mdPath = join(dir, name.endsWith('.md') ? name : `${name}.md`);
+    if (existsSync(mdPath)) {
+      return parseStandaloneSkill(mdPath, location);
     }
   }
 


### PR DESCRIPTION
## Summary
- **Live progress during clone** — spinner now shows real-time git progress (e.g. `GitHub — Receiving objects 45% 1.2 MiB`) instead of static "Fetching from GitHub..."
- **Sparse checkout for large monorepos** — tries `--filter=blob:none` + sparse checkout of `SKILL_DISCOVERY_PATHS` first, only downloading skill directories instead of the entire tree. Falls back to regular `--depth 1` clone if unsupported.
- **Shared `cloneRepo()` helper** — eliminates duplicate clone logic across GitHub, GitLab, Bitbucket, and Skills.sh providers
- **Faster clones** — adds `--single-branch --no-tags` to all git clones

## Before / After
| | Before | After |
|---|---|---|
| Progress | Static spinner "Fetching from GitHub..." | Live `Receiving objects 45% 1.2 MiB` |
| Large monorepo (iii-hq/iii) | Full tree download | **1.4s**, only `skills/` checked out |
| Clone flags | `--depth 1` | `--depth 1 --single-branch --no-tags --progress --filter=blob:none` |
| Provider code | 4x duplicated clone logic | Shared `cloneRepo()` in base.ts |

## Test plan
- [x] `pnpm build` — passes
- [x] `pnpm test` — 1076 tests passing (1035 core + 41 CLI)
- [x] Smoke test with `pro-workflow` repo — progress updates visible
- [x] Smoke test with `iii-hq/iii` monorepo — 1.4s with sparse checkout
- [ ] Test fallback path (server without partial clone support)
- [ ] Test `npx skillkit add` interactive flow end-to-end
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time cloning progress shown during installation.
  * Markdown scanning now ignores YAML frontmatter and fenced code blocks.

* **Improvements**
  * Status messages clarified to reflect cloning steps.
  * Smarter cloning: attempts partial/sparse fetch with automatic fallback and cleanup.
  * Installer better handles standalone-file installs (copy/symlink behavior and skipping dependency/metadata steps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->