### PR TITLE
feat: reusable GitHub Action, --json output, loading spinners

### DIFF
--- a/.github/actions/skillkit/README.md
+++ b/.github/actions/skillkit/README.md
@@ -1,0 +1,87 @@
+# SkillKit GitHub Action
+
+A reusable composite action to install, scan, and manage AI agent skills in CI/CD pipelines.
+
+## Usage
+
+```yaml
+# Install skills
+- uses: rohitg00/skillkit/.github/actions/skillkit@main
+  with:
+    command: install
+    source: anthropics/skills
+
+# Security scan
+- uses: rohitg00/skillkit/.github/actions/skillkit@main
+  with:
+    command: scan
+    source: ./skills
+
+# Check for updates
+- uses: rohitg00/skillkit/.github/actions/skillkit@main
+  with:
+    command: check
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `command` | SkillKit command to run (`install`, `scan`, `check`, `sync`) | Yes | |
+| `source` | Skill source for install (e.g. `owner/repo`) | No | |
+| `args` | Additional arguments | No | `''` |
+| `node-version` | Node.js version | No | `20` |
+| `agent` | Target agent (e.g. `claude-code`, `cursor`) | No | `claude-code` |
+
+## Examples
+
+### Install and sync skills
+
+```yaml
+jobs:
+  setup-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rohitg00/skillkit/.github/actions/skillkit@main
+        with:
+          command: install
+          source: anthropics/skills
+          agent: cursor
+
+      - uses: rohitg00/skillkit/.github/actions/skillkit@main
+        with:
+          command: sync
+```
+
+### Security scan on PR
+
+```yaml
+jobs:
+  scan-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rohitg00/skillkit/.github/actions/skillkit@main
+        with:
+          command: scan
+          source: ./skills
+          args: '--fail-on high'
+```
+
+### Check for updates
+
+```yaml
+jobs:
+  check-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rohitg00/skillkit/.github/actions/skillkit@main
+        with:
+          command: check
+          args: '--json'
+```

--- a/.github/actions/skillkit/action.yml
+++ b/.github/actions/skillkit/action.yml
@@ -34,11 +34,32 @@ runs:
 
     - name: Run SkillKit
       shell: bash
+      env:
+        SK_COMMAND: ${{ inputs.command }}
+        SK_SOURCE: ${{ inputs.source }}
+        SK_AGENT: ${{ inputs.agent }}
+        SK_ARGS: ${{ inputs.args }}
       run: |
-        if [ "${{ inputs.command }}" = "install" ] && [ -n "${{ inputs.source }}" ]; then
-          skillkit install "${{ inputs.source }}" --agent "${{ inputs.agent }}" --yes --json ${{ inputs.args }}
-        elif [ "${{ inputs.command }}" = "scan" ] && [ -n "${{ inputs.source }}" ]; then
-          skillkit scan "${{ inputs.source }}" --json ${{ inputs.args }}
-        else
-          skillkit ${{ inputs.command }} ${{ inputs.args }}
-        fi
+        case "${SK_COMMAND}" in
+          install)
+            if [ -n "${SK_SOURCE}" ]; then
+              skillkit install "${SK_SOURCE}" --agent "${SK_AGENT}" --yes --json ${SK_ARGS}
+            else
+              echo "Error: source is required for install" >&2; exit 1
+            fi
+            ;;
+          scan)
+            if [ -n "${SK_SOURCE}" ]; then
+              skillkit scan "${SK_SOURCE}" --json ${SK_ARGS}
+            else
+              echo "Error: source is required for scan" >&2; exit 1
+            fi
+            ;;
+          check|sync|list|update)
+            skillkit "${SK_COMMAND}" ${SK_ARGS}
+            ;;
+          *)
+            echo "Error: unsupported command '${SK_COMMAND}'. Use: install, scan, check, sync, list, update" >&2
+            exit 1
+            ;;
+        esac

--- a/.github/actions/skillkit/action.yml
+++ b/.github/actions/skillkit/action.yml
@@ -1,0 +1,44 @@
+name: 'SkillKit'
+description: 'Install, scan, and manage AI agent skills in CI/CD'
+inputs:
+  command:
+    description: 'SkillKit command to run (install, scan, check, sync)'
+    required: true
+  source:
+    description: 'Skill source for install (e.g. owner/repo)'
+    required: false
+  args:
+    description: 'Additional arguments'
+    required: false
+    default: ''
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '20'
+  agent:
+    description: 'Target agent (e.g. claude-code, cursor)'
+    required: false
+    default: 'claude-code'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install SkillKit
+      shell: bash
+      run: npm install -g skillkit@latest
+
+    - name: Run SkillKit
+      shell: bash
+      run: |
+        if [ "${{ inputs.command }}" = "install" ] && [ -n "${{ inputs.source }}" ]; then
+          skillkit install "${{ inputs.source }}" --agent "${{ inputs.agent }}" --yes --json ${{ inputs.args }}
+        elif [ "${{ inputs.command }}" = "scan" ] && [ -n "${{ inputs.source }}" ]; then
+          skillkit scan "${{ inputs.source }}" --json ${{ inputs.args }}
+        else
+          skillkit ${{ inputs.command }} ${{ inputs.args }}
+        fi

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -52,11 +52,15 @@ export class CheckCommand extends Command {
     description: 'Minimal output',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const searchDirs = getSearchDirs();
     const s = spinner();
 
-    if (!this.quiet) {
+    if (!this.quiet && !this.json) {
       header('Check Updates');
     }
 
@@ -85,7 +89,7 @@ export class CheckCommand extends Command {
       return 0;
     }
 
-    if (!this.quiet) {
+    if (!this.quiet && !this.json) {
       step(`Checking ${skillsToCheck.length} skill(s) for updates...`);
       console.log('');
     }
@@ -193,6 +197,19 @@ export class CheckCommand extends Command {
         });
         if (this.verbose) s.stop(`${skill.name}: error`);
       }
+    }
+
+    if (this.json) {
+      console.log(JSON.stringify({
+        skills: results.map((r) => ({
+          name: r.name,
+          hasUpdate: r.hasUpdate,
+          quality: r.qualityScore ?? null,
+          stars: r.stars ?? null,
+        })),
+        updatesAvailable,
+      }));
+      return 0;
     }
 
     console.log('');

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -58,7 +58,7 @@ export class CheckCommand extends Command {
 
   async execute(): Promise<number> {
     const searchDirs = getSearchDirs();
-    const s = spinner();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
 
     if (!this.quiet && !this.json) {
       header('Check Updates');

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -12,6 +12,7 @@ import {
   CommunitySignalsEvaluator,
 } from '@skillkit/core';
 import type { EvalTier, EvalOptions } from '@skillkit/core';
+import { spinner } from '../onboarding/index.js';
 
 export class EvalCommand extends Command {
   static override paths = [['eval']];
@@ -132,7 +133,10 @@ export class EvalCommand extends Command {
     engine.registerEvaluator(new DynamicBenchmarkEvaluator());
     engine.registerEvaluator(new CommunitySignalsEvaluator());
 
+    const s = spinner();
+    s.start('Evaluating skill...');
     const result = await engine.evaluate(targetPath, options);
+    s.stop(`Evaluation complete (score: ${result.overallScore})`);
 
     this.context.stdout.write(formatEvalResult(result, this.format) + '\n');
 

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -133,10 +133,17 @@ export class EvalCommand extends Command {
     engine.registerEvaluator(new DynamicBenchmarkEvaluator());
     engine.registerEvaluator(new CommunitySignalsEvaluator());
 
-    const s = spinner();
+    const isJson = this.format === 'json';
+    const s = isJson ? { start: () => {}, stop: () => {} } : spinner();
     s.start('Evaluating skill...');
-    const result = await engine.evaluate(targetPath, options);
-    s.stop(`Evaluation complete (score: ${result.overallScore})`);
+    let result;
+    try {
+      result = await engine.evaluate(targetPath, options);
+      s.stop(`Evaluation complete (score: ${result.overallScore})`);
+    } catch (err) {
+      s.stop('Evaluation failed');
+      throw err;
+    }
 
     this.context.stdout.write(formatEvalResult(result, this.format) + '\n');
 

--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -65,11 +65,15 @@ export class FindCommand extends Command {
     hidden: true,
   });
 
+  json = Option.Boolean("--json", false, {
+    description: "Output as JSON",
+  });
+
   async execute(): Promise<number> {
     const s = spinner();
     const limit = parseInt(this.limit, 10) || 10;
 
-    if (!this.quiet) {
+    if (!this.quiet && !this.json) {
       header("Find Skills");
     }
 
@@ -250,6 +254,18 @@ export class FindCommand extends Command {
       } catch {
         s.stop(colors.warning("External search unavailable"));
       }
+    }
+
+    if (this.json) {
+      console.log(JSON.stringify({
+        results: results.map((r) => ({
+          name: r.name,
+          description: r.description || "",
+          source: r.source,
+        })),
+        total: results.length,
+      }));
+      return 0;
     }
 
     if (results.length === 0) {

--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -70,7 +70,7 @@ export class FindCommand extends Command {
   });
 
   async execute(): Promise<number> {
-    const s = spinner();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     const limit = parseInt(this.limit, 10) || 10;
 
     if (!this.quiet && !this.json) {

--- a/packages/cli/src/commands/find.ts
+++ b/packages/cli/src/commands/find.ts
@@ -121,7 +121,7 @@ export class FindCommand extends Command {
         )
         .slice(0, limit);
 
-      if (!this.quiet) {
+      if (!this.quiet && !this.json) {
         step("Showing featured skills");
       }
     } else if (this.query) {
@@ -142,7 +142,7 @@ export class FindCommand extends Command {
 
       s.stop(`Found ${results.length} skill(s)`);
     } else {
-      if (!this.quiet) {
+      if (!this.quiet && !this.json) {
         step("Enter a search term or browse featured skills");
       }
 

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -140,7 +140,7 @@ export class InstallCommand extends Command {
   async execute(): Promise<number> {
     const isInteractive =
       process.stdin.isTTY && !this.skills && !this.all && !this.yes && !this.json;
-    const s = spinner();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     let cloneResult: Awaited<ReturnType<typeof this.resolveSource>>["cloneResult"] = null;
 
     try {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -186,8 +186,12 @@ export class InstallCommand extends Command {
 
       return 0;
     } catch (err) {
-      s.stop(colors.error("Installation failed"));
-      console.log(colors.muted(err instanceof Error ? err.message : String(err)));
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: err instanceof Error ? err.message : String(err) }));
+      } else {
+        s.stop(colors.error("Installation failed"));
+        console.log(colors.muted(err instanceof Error ? err.message : String(err)));
+      }
       return 1;
     } finally {
       if (cloneResult) this.cleanupTemp(cloneResult);

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -133,14 +133,18 @@ export class InstallCommand extends Command {
     description: "Run security scan before installing (default: true)",
   });
 
+  json = Option.Boolean("--json", false, {
+    description: "Output as JSON",
+  });
+
   async execute(): Promise<number> {
     const isInteractive =
-      process.stdin.isTTY && !this.skills && !this.all && !this.yes;
+      process.stdin.isTTY && !this.skills && !this.all && !this.yes && !this.json;
     const s = spinner();
     let cloneResult: Awaited<ReturnType<typeof this.resolveSource>>["cloneResult"] = null;
 
     try {
-      if (process.stdin.isTTY && !this.quiet) {
+      if (process.stdin.isTTY && !this.quiet && !this.json) {
         welcome();
       }
 
@@ -657,6 +661,16 @@ export class InstallCommand extends Command {
     providerAdapter: ReturnType<typeof detectProvider>,
     isInteractive: boolean,
   ): Promise<void> {
+    if (this.json) {
+      console.log(JSON.stringify({
+        success: true,
+        installed: installResults.map((r) => r.skillName),
+        agents: targetAgents,
+        total: installResults.length,
+      }));
+      return;
+    }
+
     if (installResults.length > 0) {
       if (isInteractive) {
         showInstallSummary({

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -59,7 +59,14 @@ export class ListCommand extends Command {
       : skills.map(s => ({ ...s, quality: null as number | null }));
 
     if (this.json) {
-      console.log(JSON.stringify(skillsWithQuality, null, 2));
+      console.log(JSON.stringify({
+        skills: skillsWithQuality.map((s) => ({
+          name: s.name,
+          enabled: s.enabled,
+          path: s.path,
+        })),
+        total: skillsWithQuality.length,
+      }));
       return 0;
     }
 

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -453,6 +453,10 @@ export class PublishSubmitCommand extends Command {
     description: "Show what would be submitted",
   });
 
+  json = Option.Boolean("--json", false, {
+    description: "Output as JSON",
+  });
+
   async execute(): Promise<number> {
     const skillPath = this.skillPath || process.cwd();
     const skillMdPath = this.findSkillMd(skillPath);
@@ -465,7 +469,7 @@ export class PublishSubmitCommand extends Command {
       return 1;
     }
 
-    step("Submitting skill to SkillKit marketplace...\n");
+    if (!this.json) step("Submitting skill to SkillKit marketplace...\n");
 
     const content = readFileSync(skillMdPath, "utf-8");
     const frontmatter = this.parseFrontmatter(content);
@@ -508,26 +512,28 @@ export class PublishSubmitCommand extends Command {
       tags: frontmatter.tags || ["general"],
     };
 
-    console.log(colors.primary("Skill details:"));
-    console.log(colors.muted(`  ID: ${skillEntry.id}`));
-    console.log(colors.muted(`  Name: ${skillEntry.name}`));
-    console.log(colors.muted(`  Description: ${skillEntry.description}`));
-    console.log(colors.muted(`  Source: ${skillEntry.source}`));
-    console.log(colors.muted(`  Tags: ${skillEntry.tags.join(", ")}`));
-    console.log(colors.muted(`  Quality: ${qualityBadge}${qualityScore !== null ? ` (${qualityScore}/100)` : ""}`));
-    if (activity) {
-      const stars = formatCount(activity.stars);
-      const pushed = activity.pushedAt ? timeAgo(activity.pushedAt) : "unknown";
-      console.log(colors.muted(`  Stars: ${stars}`));
-      console.log(colors.muted(`  Last push: ${pushed}`));
-    }
-    if (quality && quality.warnings.length > 0) {
-      console.log(colors.warning(`  Warnings:`));
-      for (const w of quality.warnings.slice(0, 3)) {
-        console.log(colors.muted(`    - ${w}`));
+    if (!this.json) {
+      console.log(colors.primary("Skill details:"));
+      console.log(colors.muted(`  ID: ${skillEntry.id}`));
+      console.log(colors.muted(`  Name: ${skillEntry.name}`));
+      console.log(colors.muted(`  Description: ${skillEntry.description}`));
+      console.log(colors.muted(`  Source: ${skillEntry.source}`));
+      console.log(colors.muted(`  Tags: ${skillEntry.tags.join(", ")}`));
+      console.log(colors.muted(`  Quality: ${qualityBadge}${qualityScore !== null ? ` (${qualityScore}/100)` : ""}`));
+      if (activity) {
+        const stars = formatCount(activity.stars);
+        const pushed = activity.pushedAt ? timeAgo(activity.pushedAt) : "unknown";
+        console.log(colors.muted(`  Stars: ${stars}`));
+        console.log(colors.muted(`  Last push: ${pushed}`));
       }
+      if (quality && quality.warnings.length > 0) {
+        console.log(colors.warning(`  Warnings:`));
+        for (const w of quality.warnings.slice(0, 3)) {
+          console.log(colors.muted(`    - ${w}`));
+        }
+      }
+      console.log();
     }
-    console.log();
 
     if (this.dryRun) {
       warn("Dry run - not submitting");
@@ -566,6 +572,15 @@ export class PublishSubmitCommand extends Command {
         },
       ).trim();
 
+      if (this.json) {
+        console.log(JSON.stringify({
+          success: true,
+          source: `${repoInfo.owner}/${repoInfo.repo}`,
+          quality: qualityScore,
+          issueUrl: result || "",
+        }));
+        return 0;
+      }
       success("Submission created!");
       if (result) {
         console.log(colors.muted(`  ${result}`));

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -13,6 +13,7 @@ import {
   success,
   error,
   step,
+  spinner,
   formatQualityBadge,
   getQualityGradeFromScore,
 } from "../onboarding/index.js";
@@ -146,9 +147,12 @@ export class PublishCommand extends Command {
     const basePath = this.skillPath || process.cwd();
     const outputDir = this.output || basePath;
 
-    step("Generating well-known skills structure...\n");
+    const s = spinner();
+    s.start("Generating well-known skills structure...");
 
     const discoveredSkills = this.discoverSkills(basePath);
+
+    s.stop(`Discovered ${discoveredSkills.length} skill(s)`);
 
     if (discoveredSkills.length === 0) {
       error("No skills found");

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -55,22 +55,30 @@ export class RemoveCommand extends Command {
           return meta?.source?.includes(this.source!) ?? false;
         }).map((s) => ({ name: s.name, path: s.path }));
         if (skillsToRemove.length === 0) {
-          warn(`No skills found from source: ${this.source}`);
+          if (this.json) {
+            console.log(JSON.stringify({ success: true, removed: [], failed: [], total: 0 }));
+          } else {
+            warn(`No skills found from source: ${this.source}`);
+          }
           return 0;
         }
       } else {
         skillsToRemove = allSkills.map((s) => ({ name: s.name, path: s.path }));
         if (skillsToRemove.length === 0) {
-          warn('No installed skills found');
+          if (this.json) {
+            console.log(JSON.stringify({ success: true, removed: [], failed: [], total: 0 }));
+          } else {
+            warn('No installed skills found');
+          }
           return 0;
         }
       }
-      console.log(colors.muted(`Found ${skillsToRemove.length} skill(s) to remove`));
+      if (!this.json) console.log(colors.muted(`Found ${skillsToRemove.length} skill(s) to remove`));
     } else {
       for (const skillName of this.skills) {
         const skill = findSkill(skillName, searchDirs);
         if (!skill) {
-          warn(`Skill not found: ${skillName}`);
+          if (!this.json) warn(`Skill not found: ${skillName}`);
           continue;
         }
         skillsToRemove.push({ name: skill.name, path: skill.path });

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -33,6 +33,10 @@ export class RemoveCommand extends Command {
     description: 'Skip confirmation',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const searchDirs = getSearchDirs();
 
@@ -75,6 +79,8 @@ export class RemoveCommand extends Command {
 
     let removed = 0;
     let failed = 0;
+    const removedNames: string[] = [];
+    const failedNames: string[] = [];
 
     for (const { name: skillName, path: skillPath } of skillsToRemove) {
       if (!existsSync(skillPath)) {
@@ -89,13 +95,27 @@ export class RemoveCommand extends Command {
           if (existsSync(metaSibling)) rmSync(metaSibling);
         }
         removeSkillFromLock(skillName);
-        success(`Removed: ${skillName}`);
+        removedNames.push(skillName);
+        if (!this.json) success(`Removed: ${skillName}`);
         removed++;
       } catch (err) {
-        error(`Failed to remove: ${skillName}`);
-        console.error(colors.muted(err instanceof Error ? err.message : String(err)));
+        failedNames.push(skillName);
+        if (!this.json) {
+          error(`Failed to remove: ${skillName}`);
+          console.error(colors.muted(err instanceof Error ? err.message : String(err)));
+        }
         failed++;
       }
+    }
+
+    if (this.json) {
+      console.log(JSON.stringify({
+        success: failed === 0,
+        removed: removedNames,
+        failed: failedNames,
+        total: removed + failed,
+      }));
+      return failed > 0 ? 1 : 0;
     }
 
     if (removed > 0) {

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -108,16 +108,6 @@ export class RemoveCommand extends Command {
       }
     }
 
-    if (this.json) {
-      console.log(JSON.stringify({
-        success: failed === 0,
-        removed: removedNames,
-        failed: failedNames,
-        total: removed + failed,
-      }));
-      return failed > 0 ? 1 : 0;
-    }
-
     if (removed > 0) {
       try {
         const agentsMdPath = join(process.cwd(), 'AGENTS.md');
@@ -135,7 +125,19 @@ export class RemoveCommand extends Command {
         warn('Warning: Failed to update AGENTS.md');
         console.error(colors.muted(err instanceof Error ? err.message : String(err)));
       }
-      console.log(colors.muted('\nRun `skillkit sync` to update your agent config'));
+      if (!this.json) {
+        console.log(colors.muted('\nRun `skillkit sync` to update your agent config'));
+      }
+    }
+
+    if (this.json) {
+      console.log(JSON.stringify({
+        success: failed === 0,
+        removed: removedNames,
+        failed: failedNames,
+        total: removed + failed,
+      }));
+      return failed > 0 ? 1 : 0;
     }
 
     return failed > 0 ? 1 : 0;

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -81,10 +81,16 @@ export class ScanCommand extends Command {
       skipRules,
     });
 
-    const s = spinner();
-    if (!this.json) s.start('Scanning for vulnerabilities...');
-    const result = await scanner.scan(targetPath);
-    if (!this.json) s.stop(`Scan complete (${result.findings.length} finding(s))`);
+    const s = this.json ? { start: () => {}, stop: () => {} } : spinner();
+    s.start('Scanning for vulnerabilities...');
+    let result;
+    try {
+      result = await scanner.scan(targetPath);
+      s.stop(`Scan complete (${result.findings.length} finding(s))`);
+    } catch (err) {
+      s.stop('Scan failed');
+      throw err;
+    }
 
     if (this.json) {
       this.context.stdout.write(formatResult(result, 'json') + '\n');

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -47,6 +47,10 @@ export class ScanCommand extends Command {
     description: 'Comma-separated rule IDs or categories to skip',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const targetPath = resolve(this.skillPath);
 
@@ -78,6 +82,11 @@ export class ScanCommand extends Command {
     });
 
     const result = await scanner.scan(targetPath);
+
+    if (this.json) {
+      this.context.stdout.write(formatResult(result, 'json') + '\n');
+      return result.verdict === 'fail' ? 1 : 0;
+    }
 
     this.context.stdout.write(formatResult(result, this.format) + '\n');
 

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -2,7 +2,7 @@ import { Command, Option } from 'clipanion';
 import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { SkillScanner, formatResult, Severity } from '@skillkit/core';
-import { error } from '../onboarding/index.js';
+import { error, spinner } from '../onboarding/index.js';
 
 const SEVERITY_MAP: Record<string, Severity> = {
   critical: Severity.CRITICAL,
@@ -81,7 +81,10 @@ export class ScanCommand extends Command {
       skipRules,
     });
 
+    const s = spinner();
+    if (!this.json) s.start('Scanning for vulnerabilities...');
     const result = await scanner.scan(targetPath);
+    if (!this.json) s.stop(`Scan complete (${result.findings.length} finding(s))`);
 
     if (this.json) {
       this.context.stdout.write(formatResult(result, 'json') + '\n');

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -91,8 +91,9 @@ export class SyncCommand extends Command {
 
         agentType = agentResult as AgentType;
       } else {
-        // Non-interactive: always detect, don't rely on default config
+        s.start('Detecting agent...');
         agentType = await detectAgent();
+        s.stop(`Detected: ${formatAgent(agentType)}`);
       }
 
       const adapter = getAdapter(agentType);

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from 'clipanion';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, basename, dirname } from 'node:path';
-import { colors, warn, success, error } from '../onboarding/index.js';
+import { colors, warn, success, error, spinner } from '../onboarding/index.js';
 import {
   type AgentType,
   translateSkill,
@@ -226,6 +226,7 @@ export class TranslateCommand extends Command {
 
     let successCount = 0;
     let failed = 0;
+    const s = spinner();
 
     for (const skill of skills) {
       const skillMdPath = join(skill.path, 'SKILL.md');
@@ -235,9 +236,13 @@ export class TranslateCommand extends Command {
         continue;
       }
 
+      s.start(`Translating ${skill.name}...`);
+
       const result = translateSkillFile(skillMdPath, targetAgent, {
         addMetadata: this.metadata,
       });
+
+      s.stop(`Translated ${skill.name}`);
 
       if (result.success) {
         if (this.dryRun) {
@@ -332,11 +337,16 @@ export class TranslateCommand extends Command {
     }
 
     // Read and translate
+    const s = spinner();
+    s.start(`Translating to ${targetAgent}...`);
+
     const content = readFileSync(sourcePath!, 'utf-8');
     const result = translateSkill(content, targetAgent, {
       addMetadata: this.metadata,
       sourceFilename: basename(sourcePath!),
     });
+
+    s.stop(`Translation complete`);
 
     if (!result.success) {
       error('Translation failed:');

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -23,6 +23,10 @@ export class UpdateCommand extends Command {
     description: 'Force update even if local changes exist',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const s = spinner();
     const searchDirs = getSearchDirs();
@@ -175,6 +179,11 @@ export class UpdateCommand extends Command {
         console.log(colors.muted(err instanceof Error ? err.message : String(err)));
         failed++;
       }
+    }
+
+    if (this.json) {
+      console.log(JSON.stringify({ updated, skipped, failed }));
+      return failed > 0 ? 1 : 0;
     }
 
     console.log();

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -39,7 +39,7 @@ export class UpdateCommand extends Command {
         .filter((s): s is NonNullable<typeof s> => s !== null);
 
       const notFound = this.skills.filter(name => !findSkill(name, searchDirs));
-      if (notFound.length > 0) {
+      if (notFound.length > 0 && !this.json) {
         warn(`Skills not found: ${notFound.join(', ')}`);
       }
     } else {
@@ -47,7 +47,11 @@ export class UpdateCommand extends Command {
     }
 
     if (skillsToUpdate.length === 0) {
-      warn('No skills to update');
+      if (this.json) {
+        console.log(JSON.stringify({ updated: 0, skipped: 0, failed: 0 }));
+      } else {
+        warn('No skills to update');
+      }
       return 0;
     }
 
@@ -61,7 +65,7 @@ export class UpdateCommand extends Command {
       const metadata = loadSkillMetadata(skill.path);
 
       if (!metadata) {
-        console.log(colors.muted(`Skipping ${skill.name} (no metadata, reinstall needed)`));
+        if (!this.json) console.log(colors.muted(`Skipping ${skill.name} (no metadata, reinstall needed)`));
         skipped++;
         continue;
       }
@@ -176,7 +180,7 @@ export class UpdateCommand extends Command {
         }
       } catch (err) {
         s.stop(colors.error(`Failed to update ${skill.name}`));
-        console.log(colors.muted(err instanceof Error ? err.message : String(err)));
+        if (!this.json) console.log(colors.muted(err instanceof Error ? err.message : String(err)));
         failed++;
       }
     }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -28,7 +28,7 @@ export class UpdateCommand extends Command {
   });
 
   async execute(): Promise<number> {
-    const s = spinner();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     const searchDirs = getSearchDirs();
 
     let skillsToUpdate;
@@ -51,7 +51,7 @@ export class UpdateCommand extends Command {
       return 0;
     }
 
-    step(`Updating ${skillsToUpdate.length} skill(s)...`);
+    if (!this.json) step(`Updating ${skillsToUpdate.length} skill(s)...`);
 
     let updated = 0;
     let skipped = 0;


### PR DESCRIPTION
## Summary

Closes #92 (partially), #89 (top 8), #88 (top 5).

### Reusable GitHub Action (#92)
`.github/actions/skillkit/action.yml` — composite action for CI/CD:
```yaml
- uses: rohitg00/skillkit/.github/actions/skillkit@main
  with:
    command: install
    source: anthropics/skills
```
Supports: install, scan, check, sync.

### --json output for 8 commands (#89)
All return structured JSON when `--json` is passed:
- `skillkit install --json` → `{success, installed, agents, total}`
- `skillkit remove --json` → `{success, removed, failed, total}`
- `skillkit check --json` → `{skills, updatesAvailable}`
- `skillkit find --json` → `{results, total}`
- `skillkit list --json` → `{skills, total}`
- `skillkit update --json` → `{updated, skipped, failed}`
- `skillkit publish submit --json` → `{success, source, quality, issueUrl}`
- `skillkit scan --json` → scan result object

### Loading spinners for 5 commands (#88)
Added progress feedback to: translate, sync, eval, publish, scan.

## Test plan
- [x] `pnpm build` — 13/13
- [x] `pnpm test` — all pass
- [ ] `skillkit install anthropics/skills --json`
- [ ] `skillkit check --json`
- [ ] `skillkit find react --json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "SkillKit" GitHub Action for installing, scanning, and managing skills in CI/CD.
  * Introduced a --json output option across many CLI commands for machine-readable single-object outputs.

* **Enhancements**
  * Improved interactive feedback with consistent spinner lifecycle and better non-interactive status reporting.

* **Documentation**
  * Added a README documenting the new action, usage examples, and inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->