### PR TITLE
feat: complete --json and spinners for all remaining commands

### DIFF
--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -2,7 +2,7 @@ import { Command, Option } from 'clipanion';
 import { resolve } from 'node:path';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { colors, warn, success } from '../onboarding/index.js';
+import { colors, warn, success, spinner } from '../onboarding/index.js';
 import { AuditLogger, type AuditQuery, type AuditEventType } from '@skillkit/core';
 
 export class AuditCommand extends Command {
@@ -114,8 +114,11 @@ export class AuditCommand extends Command {
   }
 
   private async handleLog(logger: AuditLogger): Promise<number> {
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
+    s.start('Querying audit log');
     const query = this.buildQuery();
     const events = await logger.query(query);
+    s.stop('Query complete');
 
     if (this.json) {
       console.log(JSON.stringify(events, null, 2));
@@ -163,10 +166,13 @@ export class AuditCommand extends Command {
   }
 
   private async handleExport(logger: AuditLogger): Promise<number> {
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     const format = (this.format as 'json' | 'csv' | 'text') || 'json';
     const query = this.buildQuery();
 
+    s.start('Exporting audit log');
     const content = await logger.export({ format, query });
+    s.stop('Export complete');
 
     if (this.output) {
       const outputPath = resolve(this.output);
@@ -180,7 +186,10 @@ export class AuditCommand extends Command {
   }
 
   private async handleStats(logger: AuditLogger): Promise<number> {
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
+    s.start('Computing statistics');
     const stats = await logger.stats();
+    s.stop('Statistics computed');
 
     if (this.json) {
       console.log(JSON.stringify(stats, null, 2));
@@ -237,9 +246,16 @@ export class AuditCommand extends Command {
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - daysAgo);
 
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
+    s.start('Clearing old entries');
     const cleared = await logger.clear(cutoffDate);
+    s.stop('Clear complete');
 
-    success(`✓ Cleared ${cleared} audit entries older than ${daysAgo} days`);
+    if (this.json) {
+      console.log(JSON.stringify({ success: true, cleared, days: daysAgo }));
+    } else {
+      success(`✓ Cleared ${cleared} audit entries older than ${daysAgo} days`);
+    }
 
     return 0;
   }

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { colors, success, error, step } from '../onboarding/index.js';
+import { colors, success, error, step, spinner } from '../onboarding/index.js';
 import { Command, Option } from 'clipanion';
 
 export class CreateCommand extends Command {
@@ -37,12 +37,21 @@ export class CreateCommand extends Command {
     description: 'Parent directory to create skill in (default: current directory)',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const skillName = this.name.toLowerCase();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
 
     if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(skillName)) {
-      error('Invalid skill name');
-      console.log(colors.muted('Must be lowercase alphanumeric with hyphens (e.g., my-skill)'));
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: 'Invalid skill name' }));
+      } else {
+        error('Invalid skill name');
+        console.log(colors.muted('Must be lowercase alphanumeric with hyphens (e.g., my-skill)'));
+      }
       return 1;
     }
 
@@ -50,11 +59,17 @@ export class CreateCommand extends Command {
     const skillDir = join(parentDir, skillName);
 
     if (existsSync(skillDir)) {
-      error(`Directory already exists: ${skillDir}`);
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: `Directory already exists: ${skillDir}` }));
+      } else {
+        error(`Directory already exists: ${skillDir}`);
+      }
       return 1;
     }
 
     try {
+      s.start('Creating skill');
+
       mkdirSync(skillDir, { recursive: true });
 
       const skillMd = generateSkillMd(skillName);
@@ -78,24 +93,35 @@ export class CreateCommand extends Command {
         writeFileSync(join(assetsDir, '.gitkeep'), '');
       }
 
-      success(`Created skill: ${skillName}`);
-      console.log();
-      console.log(colors.muted('Structure:'));
-      console.log(colors.muted(`  ${skillDir}/`));
-      console.log(colors.muted('  ├── SKILL.md'));
-      if (this.full || this.references) console.log(colors.muted('  ├── references/'));
-      if (this.full || this.scripts) console.log(colors.muted('  ├── scripts/'));
-      if (this.full || this.assets) console.log(colors.muted('  └── assets/'));
-      console.log();
-      step('Next steps:');
-      console.log(colors.muted('  1. Edit SKILL.md with your instructions'));
-      console.log(colors.muted('  2. Validate: skillkit validate ' + skillDir));
-      console.log(colors.muted('  3. Test: skillkit read ' + skillName));
+      s.stop('Skill created');
+
+      if (this.json) {
+        console.log(JSON.stringify({ success: true, name: skillName, path: skillDir }));
+      } else {
+        success(`Created skill: ${skillName}`);
+        console.log();
+        console.log(colors.muted('Structure:'));
+        console.log(colors.muted(`  ${skillDir}/`));
+        console.log(colors.muted('  ├── SKILL.md'));
+        if (this.full || this.references) console.log(colors.muted('  ├── references/'));
+        if (this.full || this.scripts) console.log(colors.muted('  ├── scripts/'));
+        if (this.full || this.assets) console.log(colors.muted('  └── assets/'));
+        console.log();
+        step('Next steps:');
+        console.log(colors.muted('  1. Edit SKILL.md with your instructions'));
+        console.log(colors.muted('  2. Validate: skillkit validate ' + skillDir));
+        console.log(colors.muted('  3. Test: skillkit read ' + skillName));
+      }
 
       return 0;
     } catch (err) {
-      error('Failed to create skill');
-      console.log(colors.muted(err instanceof Error ? err.message : String(err)));
+      s.stop('Failed');
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: err instanceof Error ? err.message : String(err) }));
+      } else {
+        error('Failed to create skill');
+        console.log(colors.muted(err instanceof Error ? err.message : String(err)));
+      }
       return 1;
     }
   }

--- a/packages/cli/src/commands/enable.ts
+++ b/packages/cli/src/commands/enable.ts
@@ -1,4 +1,4 @@
-import { colors, warn, success, error } from '../onboarding/index.js';
+import { colors, warn, success, error, spinner } from '../onboarding/index.js';
 import { Command, Option } from 'clipanion';
 import { setSkillEnabled, findSkill } from '@skillkit/core';
 import { getSearchDirs } from '../helpers.js';
@@ -16,37 +16,53 @@ export class EnableCommand extends Command {
 
   skills = Option.Rest({ required: 1 });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const searchDirs = getSearchDirs();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     let successCount = 0;
     let failed = 0;
+    const results: Array<{ name: string; enabled: boolean; success: boolean }> = [];
+
+    s.start('Enabling skills');
 
     for (const skillName of this.skills) {
       const skill = findSkill(skillName, searchDirs);
 
       if (!skill) {
-        error(`Skill not found: ${skillName}`);
+        if (!this.json) error(`Skill not found: ${skillName}`);
+        results.push({ name: skillName, enabled: false, success: false });
         failed++;
         continue;
       }
 
       if (skill.enabled) {
-        console.log(colors.muted(`Already enabled: ${skillName}`));
+        if (!this.json) console.log(colors.muted(`Already enabled: ${skillName}`));
+        results.push({ name: skillName, enabled: true, success: true });
         continue;
       }
 
       const result = setSkillEnabled(skill.path, true);
 
       if (result) {
-        success(`Enabled: ${skillName}`);
+        if (!this.json) success(`Enabled: ${skillName}`);
+        results.push({ name: skillName, enabled: true, success: true });
         successCount++;
       } else {
-        error(`Failed to enable: ${skillName}`);
+        if (!this.json) error(`Failed to enable: ${skillName}`);
+        results.push({ name: skillName, enabled: false, success: false });
         failed++;
       }
     }
 
-    if (successCount > 0) {
+    s.stop(successCount > 0 ? `Enabled ${successCount} skill(s)` : 'Done');
+
+    if (this.json) {
+      console.log(JSON.stringify({ success: failed === 0, results }));
+    } else if (successCount > 0) {
       console.log(colors.muted('\nRun `skillkit sync` to update your agent config'));
     }
 
@@ -67,37 +83,53 @@ export class DisableCommand extends Command {
 
   skills = Option.Rest({ required: 1 });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const searchDirs = getSearchDirs();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     let successCount = 0;
     let failed = 0;
+    const results: Array<{ name: string; enabled: boolean; success: boolean }> = [];
+
+    s.start('Disabling skills');
 
     for (const skillName of this.skills) {
       const skill = findSkill(skillName, searchDirs);
 
       if (!skill) {
-        error(`Skill not found: ${skillName}`);
+        if (!this.json) error(`Skill not found: ${skillName}`);
+        results.push({ name: skillName, enabled: false, success: false });
         failed++;
         continue;
       }
 
       if (!skill.enabled) {
-        console.log(colors.muted(`Already disabled: ${skillName}`));
+        if (!this.json) console.log(colors.muted(`Already disabled: ${skillName}`));
+        results.push({ name: skillName, enabled: false, success: true });
         continue;
       }
 
       const result = setSkillEnabled(skill.path, false);
 
       if (result) {
-        warn(`Disabled: ${skillName}`);
+        if (!this.json) warn(`Disabled: ${skillName}`);
+        results.push({ name: skillName, enabled: false, success: true });
         successCount++;
       } else {
-        error(`Failed to disable: ${skillName}`);
+        if (!this.json) error(`Failed to disable: ${skillName}`);
+        results.push({ name: skillName, enabled: true, success: false });
         failed++;
       }
     }
 
-    if (successCount > 0) {
+    s.stop(successCount > 0 ? `Disabled ${successCount} skill(s)` : 'Done');
+
+    if (this.json) {
+      console.log(JSON.stringify({ success: failed === 0, results }));
+    } else if (successCount > 0) {
       console.log(colors.muted('\nRun `skillkit sync` to update your agent config'));
     }
 

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -75,6 +75,10 @@ export class EvalCommand extends Command {
     description: 'Timeout in seconds for each tier',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const targetPath = resolve(this.skillPath);
 
@@ -133,8 +137,8 @@ export class EvalCommand extends Command {
     engine.registerEvaluator(new DynamicBenchmarkEvaluator());
     engine.registerEvaluator(new CommunitySignalsEvaluator());
 
-    const isJson = this.format === 'json';
-    const s = isJson ? { start: () => {}, stop: () => {} } : spinner();
+    const isJson = this.json || this.format === 'json';
+    const s = isJson ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     s.start('Evaluating skill...');
     let result;
     try {
@@ -145,12 +149,18 @@ export class EvalCommand extends Command {
       throw err;
     }
 
-    this.context.stdout.write(formatEvalResult(result, this.format) + '\n');
+    if (this.json) {
+      console.log(JSON.stringify(result));
+    } else {
+      this.context.stdout.write(formatEvalResult(result, this.format) + '\n');
+    }
 
     if (this.minScore) {
       const threshold = parseInt(this.minScore, 10);
       if (result.overallScore < threshold) {
-        this.context.stderr.write(`Score ${result.overallScore} is below minimum ${threshold}\n`);
+        if (!this.json) {
+          this.context.stderr.write(`Score ${result.overallScore} is below minimum ${threshold}\n`);
+        }
         return 1;
       }
     }

--- a/packages/cli/src/commands/fix.ts
+++ b/packages/cli/src/commands/fix.ts
@@ -15,6 +15,7 @@ import {
   error,
   header,
   confirm,
+  spinner,
 } from '../onboarding/index.js';
 
 interface FixSuggestion {
@@ -209,6 +210,7 @@ export class FixCommand extends Command {
 
     let totalFixes = 0;
     let filesFixed = 0;
+    const s = spinner();
 
     for (const target of this.targets) {
       const resolved = resolve(target);
@@ -256,8 +258,10 @@ export class FixCommand extends Command {
         continue;
       }
 
+      s.start(`Evaluating ${skillName}`);
       const content = readFileSync(filePath, 'utf-8');
       const quality = evaluateSkillFile(filePath);
+      s.stop(`Evaluated ${skillName}`);
 
       if (!quality) {
         warn(`Could not evaluate: ${target}`);

--- a/packages/cli/src/commands/hook.ts
+++ b/packages/cli/src/commands/hook.ts
@@ -5,7 +5,7 @@
  */
 
 import { Command, Option } from 'clipanion';
-import { colors } from '../onboarding/index.js';
+import { colors, spinner } from '../onboarding/index.js';
 import { createHookManager, type HookEvent, type InjectionMode } from '@skillkit/core';
 import {
   getHookTemplates,
@@ -239,7 +239,10 @@ export class HookCommand extends Command {
     }
 
     const agent = this.agent || 'claude-code';
+    const s = spinner();
+    s.start(`Generating hooks for ${agent}`);
     const generated = manager.generateAgentHooks(agent as any);
+    s.stop('Hooks generated');
 
     this.context.stdout.write(colors.cyan(`Generated hooks for ${agent}:\n\n`));
 

--- a/packages/cli/src/commands/methodology.ts
+++ b/packages/cli/src/commands/methodology.ts
@@ -5,7 +5,7 @@
  */
 
 import { Command, Option } from 'clipanion';
-import { colors } from '../onboarding/index.js';
+import { colors, spinner } from '../onboarding/index.js';
 import { createMethodologyManager, createMethodologyLoader } from '@skillkit/core';
 
 export class MethodologyCommand extends Command {
@@ -61,8 +61,11 @@ export class MethodologyCommand extends Command {
   }
 
   private async listPacks(): Promise<number> {
+    const s = spinner();
+    s.start('Loading methodology packs');
     const loader = createMethodologyLoader();
     const packs = await loader.loadAllPacks();
+    s.stop('Packs loaded');
 
     if (packs.length === 0) {
       this.context.stdout.write('No methodology packs available.\n');
@@ -91,15 +94,16 @@ export class MethodologyCommand extends Command {
     if (this.target) {
       // Check if it's a skill ID (pack/skill) or pack name
       if (this.target.includes('/')) {
-        // Install single skill
-        this.context.stdout.write(`Installing skill: ${colors.cyan(this.target)}...\n`);
+        const s = spinner();
 
         if (this.dryRun) {
           this.context.stdout.write(colors.warning('[dry-run] Would install skill.\n'));
           return 0;
         }
 
+        s.start(`Installing skill: ${this.target}`);
         const result = await manager.installSkill(this.target);
+        s.stop('Install complete');
 
         if (result.success) {
           this.context.stdout.write(colors.success(`✓ Skill installed: ${this.target}\n`));
@@ -110,8 +114,7 @@ export class MethodologyCommand extends Command {
           return 1;
         }
       } else {
-        // Install single pack
-        this.context.stdout.write(`Installing pack: ${colors.cyan(this.target)}...\n`);
+        const s = spinner();
 
         if (this.dryRun) {
           const pack = await loader.loadPack(this.target);
@@ -121,7 +124,9 @@ export class MethodologyCommand extends Command {
           return 0;
         }
 
+        s.start(`Installing pack: ${this.target}`);
         const result = await manager.installPack(this.target);
+        s.stop('Pack installed');
 
         if (result.success) {
           this.context.stdout.write(colors.success(`✓ Pack "${this.target}" installed!\n`));
@@ -138,8 +143,7 @@ export class MethodologyCommand extends Command {
         }
       }
     } else {
-      // Install all packs
-      this.context.stdout.write('Installing all methodology packs...\n\n');
+      const s = spinner();
 
       if (this.dryRun) {
         const packs = await loader.loadAllPacks();
@@ -152,7 +156,9 @@ export class MethodologyCommand extends Command {
         return 0;
       }
 
+      s.start('Installing all methodology packs');
       const result = await manager.installAllPacks();
+      s.stop('Installation complete');
 
       if (result.success) {
         this.context.stdout.write(colors.success('\n✓ All methodology packs installed!\n'));
@@ -195,15 +201,17 @@ export class MethodologyCommand extends Command {
   private async syncSkills(projectPath: string): Promise<number> {
     const manager = createMethodologyManager({ projectPath, autoSync: false });
 
-    this.context.stdout.write('Syncing methodology skills to detected agents...\n\n');
-
     if (this.dryRun) {
       const installed = manager.listInstalledSkills();
       this.context.stdout.write(colors.warning(`[dry-run] Would sync ${installed.length} skills.\n`));
       return 0;
     }
 
+    const s = spinner();
+    s.start('Syncing methodology skills');
+
     const result = await manager.syncAll();
+    s.stop('Sync complete');
 
     if (result.synced.length > 0) {
       this.context.stdout.write(colors.success('✓ Sync complete!\n'));

--- a/packages/cli/src/commands/plugin.ts
+++ b/packages/cli/src/commands/plugin.ts
@@ -8,7 +8,7 @@ import { Command, Option } from 'clipanion';
 import { join, isAbsolute, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { existsSync, mkdirSync, copyFileSync, cpSync, rmSync } from 'node:fs';
-import { colors } from '../onboarding/index.js';
+import { colors, spinner } from '../onboarding/index.js';
 import { createPluginManager, loadPlugin, loadPluginsFromDirectory } from '@skillkit/core';
 
 export class PluginCommand extends Command {
@@ -149,7 +149,8 @@ export class PluginCommand extends Command {
       ? join(homedir(), this.source.slice(1))
       : this.source;
 
-    this.context.stdout.write(`Installing plugin from ${this.source}...\n`);
+    const s = spinner();
+    s.start(`Installing plugin from ${this.source}`);
 
     const plugin = await loadPlugin(resolvedSource);
 
@@ -222,6 +223,8 @@ export class PluginCommand extends Command {
 
     await pluginManager.register(plugin);
 
+    s.stop('Plugin installed');
+
     this.context.stdout.write(colors.success(`✓ Plugin "${plugin.metadata.name}" installed!\n`));
     this.context.stdout.write(`  Version: ${plugin.metadata.version}\n`);
     if (plugin.metadata.description) {
@@ -254,9 +257,10 @@ export class PluginCommand extends Command {
       return 1;
     }
 
-    await pluginManager.unregister(this.name);
+    const s = spinner();
+    s.start(`Uninstalling plugin ${this.name}`);
 
-    // Remove plugin files from disk
+    await pluginManager.unregister(this.name);
     const projectPath = this.global
       ? join(homedir(), '.skillkit')
       : process.cwd();
@@ -275,8 +279,9 @@ export class PluginCommand extends Command {
 
     if (existsSync(pluginDir)) {
       rmSync(pluginDir, { recursive: true, force: true });
-      this.context.stdout.write(colors.muted(`  Removed ${pluginDir}\n`));
     }
+
+    s.stop('Plugin uninstalled');
 
     this.context.stdout.write(colors.success(`✓ Plugin "${this.name}" uninstalled.\n`));
     return 0;

--- a/packages/cli/src/commands/read.ts
+++ b/packages/cli/src/commands/read.ts
@@ -21,6 +21,10 @@ export class ReadCommand extends Command {
     description: 'Show additional information',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const searchDirs = getSearchDirs();
 
@@ -30,26 +34,35 @@ export class ReadCommand extends Command {
       .filter(s => s.length > 0);
 
     if (skillNames.length === 0) {
-      error('No skill names provided');
+      if (this.json) {
+        console.log(JSON.stringify({ error: 'No skill names provided' }));
+      } else {
+        error('No skill names provided');
+      }
       return 1;
     }
 
     let exitCode = 0;
+    const jsonResults: Array<{ name: string; content: string; path: string }> = [];
 
     for (const skillName of skillNames) {
       const skill = findSkill(skillName, searchDirs);
 
       if (!skill) {
-        error(`Skill not found: ${skillName}`);
-        console.log(colors.muted('Available directories:'));
-        searchDirs.forEach(d => console.log(colors.muted(`  - ${d}`)));
+        if (!this.json) {
+          error(`Skill not found: ${skillName}`);
+          console.log(colors.muted('Available directories:'));
+          searchDirs.forEach(d => console.log(colors.muted(`  - ${d}`)));
+        }
         exitCode = 1;
         continue;
       }
 
       if (!skill.enabled) {
-        warn(`Skill disabled: ${skillName}`);
-        console.log(colors.muted('Enable with: skillkit enable ' + skillName));
+        if (!this.json) {
+          warn(`Skill disabled: ${skillName}`);
+          console.log(colors.muted('Enable with: skillkit enable ' + skillName));
+        }
         exitCode = 1;
         continue;
       }
@@ -57,20 +70,32 @@ export class ReadCommand extends Command {
       const content = readSkillContent(skill.path);
 
       if (!content) {
-        error(`Could not read SKILL.md for: ${skillName}`);
+        if (!this.json) error(`Could not read SKILL.md for: ${skillName}`);
         exitCode = 1;
         continue;
       }
 
-      console.log(`Reading: ${skillName}`);
-      console.log(`Base directory: ${skill.path}`);
-      console.log();
-      console.log(content);
-      console.log();
-      console.log(`Skill read: ${skillName}`);
+      if (this.json) {
+        jsonResults.push({ name: skillName, content, path: skill.path });
+      } else {
+        console.log(`Reading: ${skillName}`);
+        console.log(`Base directory: ${skill.path}`);
+        console.log();
+        console.log(content);
+        console.log();
+        console.log(`Skill read: ${skillName}`);
 
-      if (skillNames.length > 1 && skillName !== skillNames[skillNames.length - 1]) {
-        console.log('\n---\n');
+        if (skillNames.length > 1 && skillName !== skillNames[skillNames.length - 1]) {
+          console.log('\n---\n');
+        }
+      }
+    }
+
+    if (this.json) {
+      if (jsonResults.length === 1) {
+        console.log(JSON.stringify(jsonResults[0]));
+      } else {
+        console.log(JSON.stringify(jsonResults));
       }
     }
 

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -1,6 +1,6 @@
 import { existsSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
-import { colors, warn, success, error } from '../onboarding/index.js';
+import { colors, warn, success, error, spinner } from '../onboarding/index.js';
 import { Command, Option } from 'clipanion';
 import { findSkill, findAllSkills, loadMetadata, AgentsMdParser, AgentsMdGenerator, removeSkillFromLock } from '@skillkit/core';
 import { getSearchDirs } from '../helpers.js';
@@ -89,6 +89,8 @@ export class RemoveCommand extends Command {
     let failed = 0;
     const removedNames: string[] = [];
     const failedNames: string[] = [];
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
+    s.start('Removing skills');
 
     for (const { name: skillName, path: skillPath } of skillsToRemove) {
       if (!existsSync(skillPath)) {
@@ -115,6 +117,8 @@ export class RemoveCommand extends Command {
         failed++;
       }
     }
+
+    s.stop(`Removed ${removed} skill(s)`);
 
     if (removed > 0) {
       try {

--- a/packages/cli/src/commands/save.ts
+++ b/packages/cli/src/commands/save.ts
@@ -43,14 +43,26 @@ export class SaveCommand extends Command {
     description: 'Local file path to save as a skill',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const sources = [this.url, this.text, this.file].filter(Boolean);
     if (sources.length === 0) {
-      console.log(colors.error('Provide a URL, --text, or --file'));
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: 'Provide a URL, --text, or --file' }));
+      } else {
+        console.log(colors.error('Provide a URL, --text, or --file'));
+      }
       return 1;
     }
     if (sources.length > 1) {
-      console.log(colors.error('Provide only one of: URL, --text, or --file'));
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: 'Provide only one of: URL, --text, or --file' }));
+      } else {
+        console.log(colors.error('Provide only one of: URL, --text, or --file'));
+      }
       return 1;
     }
 
@@ -58,7 +70,7 @@ export class SaveCommand extends Command {
     const generator = new SkillGenerator();
     const tagger = new AutoTagger();
 
-    const s = spinner();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
 
     try {
       s.start('Extracting content');
@@ -82,37 +94,45 @@ export class SaveCommand extends Command {
         global: this.global,
       });
 
-      s.stop(colors.success('Skill saved'));
+      s.stop('Skill saved');
 
-      console.log('');
-      console.log(colors.bold('  Name:  ') + colors.cyan(result.name));
-      console.log(colors.bold('  Path:  ') + colors.muted(result.skillPath));
-      if (tags.length > 0) {
-        console.log(colors.bold('  Tags:  ') + tags.map(t => colors.warning(t)).join(', '));
-      }
+      if (this.json) {
+        console.log(JSON.stringify({ success: true, name: result.name, path: result.skillPath }));
+      } else {
+        console.log('');
+        console.log(colors.bold('  Name:  ') + colors.cyan(result.name));
+        console.log(colors.bold('  Path:  ') + colors.muted(result.skillPath));
+        if (tags.length > 0) {
+          console.log(colors.bold('  Tags:  ') + tags.map(t => colors.warning(t)).join(', '));
+        }
 
-      if (this.agent) {
-        const agents = this.agent.split(',').map(a => a.trim()).filter(Boolean);
-        const skillDir = dirname(result.skillPath);
+        if (this.agent) {
+          const agents = this.agent.split(',').map(a => a.trim()).filter(Boolean);
+          const skillDir = dirname(result.skillPath);
 
-        for (const agentName of agents) {
-          try {
-            const adapter = getAdapter(agentName as AgentType);
-            const targetDir = join(adapter.skillsDir, result.name);
-            mkdirSync(targetDir, { recursive: true });
-            cpSync(skillDir, targetDir, { recursive: true });
-            console.log(colors.success(`  Installed to ${agentName}: `) + colors.muted(targetDir));
-          } catch (err) {
-            warn(`  Skipped ${agentName}: ${err instanceof Error ? err.message : String(err)}`);
+          for (const agentName of agents) {
+            try {
+              const adapter = getAdapter(agentName as AgentType);
+              const targetDir = join(adapter.skillsDir, result.name);
+              mkdirSync(targetDir, { recursive: true });
+              cpSync(skillDir, targetDir, { recursive: true });
+              console.log(colors.success(`  Installed to ${agentName}: `) + colors.muted(targetDir));
+            } catch (err) {
+              warn(`  Skipped ${agentName}: ${err instanceof Error ? err.message : String(err)}`);
+            }
           }
         }
-      }
 
-      console.log('');
+        console.log('');
+      }
       return 0;
     } catch (err) {
-      s.stop(colors.error('Failed'));
-      console.log(colors.error(err instanceof Error ? err.message : String(err)));
+      s.stop('Failed');
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: err instanceof Error ? err.message : String(err) }));
+      } else {
+        console.log(colors.error(err instanceof Error ? err.message : String(err)));
+      }
       return 1;
     }
   }

--- a/packages/cli/src/commands/save.ts
+++ b/packages/cli/src/commands/save.ts
@@ -96,8 +96,29 @@ export class SaveCommand extends Command {
 
       s.stop('Skill saved');
 
+      const installedAgents: string[] = [];
+      if (this.agent) {
+        const agents = this.agent.split(',').map(a => a.trim()).filter(Boolean);
+        const skillDir = dirname(result.skillPath);
+
+        for (const agentName of agents) {
+          try {
+            const adapter = getAdapter(agentName as AgentType);
+            const targetDir = join(adapter.skillsDir, result.name);
+            mkdirSync(targetDir, { recursive: true });
+            cpSync(skillDir, targetDir, { recursive: true });
+            installedAgents.push(agentName);
+            if (!this.json) {
+              console.log(colors.success(`  Installed to ${agentName}: `) + colors.muted(targetDir));
+            }
+          } catch (err) {
+            if (!this.json) warn(`  Skipped ${agentName}: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+      }
+
       if (this.json) {
-        console.log(JSON.stringify({ success: true, name: result.name, path: result.skillPath }));
+        console.log(JSON.stringify({ success: true, name: result.name, path: result.skillPath, agents: installedAgents }));
       } else {
         console.log('');
         console.log(colors.bold('  Name:  ') + colors.cyan(result.name));
@@ -105,24 +126,6 @@ export class SaveCommand extends Command {
         if (tags.length > 0) {
           console.log(colors.bold('  Tags:  ') + tags.map(t => colors.warning(t)).join(', '));
         }
-
-        if (this.agent) {
-          const agents = this.agent.split(',').map(a => a.trim()).filter(Boolean);
-          const skillDir = dirname(result.skillPath);
-
-          for (const agentName of agents) {
-            try {
-              const adapter = getAdapter(agentName as AgentType);
-              const targetDir = join(adapter.skillsDir, result.name);
-              mkdirSync(targetDir, { recursive: true });
-              cpSync(skillDir, targetDir, { recursive: true });
-              console.log(colors.success(`  Installed to ${agentName}: `) + colors.muted(targetDir));
-            } catch (err) {
-              warn(`  Skipped ${agentName}: ${err instanceof Error ? err.message : String(err)}`);
-            }
-          }
-        }
-
         console.log('');
       }
       return 0;

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -53,16 +53,20 @@ export class SyncCommand extends Command {
     description: 'Minimal output',
   });
 
-  async execute(): Promise<number> {
-    const isInteractive = process.stdin.isTTY && !this.yes;
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
 
-    if (!this.quiet) {
+  async execute(): Promise<number> {
+    const isInteractive = process.stdin.isTTY && !this.yes && !this.json;
+
+    if (!this.quiet && !this.json) {
       header('Sync Skills');
     }
 
     try {
       let agentType: AgentType;
-      const s = spinner();
+      const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
 
       if (this.agent) {
         agentType = this.agent as AgentType;
@@ -107,13 +111,16 @@ export class SyncCommand extends Command {
       }
 
       if (skills.length === 0) {
-        warn('No skills found to sync');
-        console.log(colors.muted('Install skills with: skillkit install <source>'));
+        if (this.json) {
+          console.log(JSON.stringify({ success: true, skills: 0, agent: agentType, configPath: '' }));
+        } else {
+          warn('No skills found to sync');
+          console.log(colors.muted('Install skills with: skillkit install <source>'));
+        }
         return 0;
       }
 
-      // Show skills to sync
-      if (!this.quiet) {
+      if (!this.quiet && !this.json) {
         console.log('');
         console.log(colors.bold(`Syncing ${skills.length} skill(s) for ${adapter.name}:`));
         console.log('');
@@ -128,8 +135,7 @@ export class SyncCommand extends Command {
         console.log('');
       }
 
-      // Confirm sync
-      if (isInteractive && !this.yes) {
+      if (isInteractive && !this.yes && !this.json) {
         const confirmResult = await confirm({
           message: `Sync ${skills.length} skill(s) to ${outputPath}?`,
           initialValue: true,
@@ -167,21 +173,28 @@ export class SyncCommand extends Command {
 
       s.stop('Config generated');
 
-      // Show summary
-      showSyncSummary({
-        skillCount: skills.length,
-        agentType,
-        configPath: outputPath,
-      });
+      if (this.json) {
+        console.log(JSON.stringify({ success: true, skills: skills.length, agent: agentType, configPath: outputPath }));
+      } else {
+        showSyncSummary({
+          skillCount: skills.length,
+          agentType,
+          configPath: outputPath,
+        });
 
-      if (!this.quiet) {
-        outro('Sync complete!');
+        if (!this.quiet) {
+          outro('Sync complete!');
+        }
       }
 
       return 0;
     } catch (err) {
-      console.log(colors.error('Sync failed'));
-      console.log(colors.muted(err instanceof Error ? err.message : String(err)));
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: err instanceof Error ? err.message : String(err) }));
+      } else {
+        console.log(colors.error('Sync failed'));
+        console.log(colors.muted(err instanceof Error ? err.message : String(err)));
+      }
       return 1;
     }
   }

--- a/packages/cli/src/commands/tap.ts
+++ b/packages/cli/src/commands/tap.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from 'clipanion';
-import { colors, symbols, step, success, warn } from '../onboarding/index.js';
+import { colors, symbols, step, success, warn, spinner } from '../onboarding/index.js';
 import { loadTaps, saveTaps } from '../helpers.js';
 
 export class TapAddCommand extends Command {
@@ -19,14 +19,25 @@ export class TapAddCommand extends Command {
     description: 'Display name for the tap',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     const taps = loadTaps();
 
     const exists = taps.taps.some((t) => t.source === this.source);
     if (exists) {
-      warn(`Tap already exists: ${this.source}`);
+      if (this.json) {
+        console.log(JSON.stringify({ success: true, source: this.source }));
+      } else {
+        warn(`Tap already exists: ${this.source}`);
+      }
       return 0;
     }
+
+    s.start('Adding tap');
 
     taps.taps.push({
       source: this.source,
@@ -35,8 +46,14 @@ export class TapAddCommand extends Command {
     });
     saveTaps(taps);
 
-    success(`Added tap: ${this.source}${this.name ? ` (${this.name})` : ''}`);
-    console.log(colors.muted('Skills from this source will appear in search results'));
+    s.stop('Tap added');
+
+    if (this.json) {
+      console.log(JSON.stringify({ success: true, source: this.source }));
+    } else {
+      success(`Added tap: ${this.source}${this.name ? ` (${this.name})` : ''}`);
+      console.log(colors.muted('Skills from this source will appear in search results'));
+    }
     return 0;
   }
 }
@@ -53,19 +70,34 @@ export class TapRemoveCommand extends Command {
 
   source = Option.String({ required: true });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     const taps = loadTaps();
 
     const idx = taps.taps.findIndex((t) => t.source === this.source);
     if (idx === -1) {
-      warn(`Tap not found: ${this.source}`);
+      if (this.json) {
+        console.log(JSON.stringify({ success: true, source: this.source }));
+      } else {
+        warn(`Tap not found: ${this.source}`);
+      }
       return 0;
     }
 
+    s.start('Removing tap');
     taps.taps.splice(idx, 1);
     saveTaps(taps);
+    s.stop('Tap removed');
 
-    success(`Removed tap: ${this.source}`);
+    if (this.json) {
+      console.log(JSON.stringify({ success: true, source: this.source }));
+    } else {
+      success(`Removed tap: ${this.source}`);
+    }
     return 0;
   }
 }
@@ -80,8 +112,17 @@ export class TapListCommand extends Command {
     ],
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     const taps = loadTaps();
+
+    if (this.json) {
+      console.log(JSON.stringify({ taps: taps.taps }));
+      return 0;
+    }
 
     if (taps.taps.length === 0) {
       step('No custom taps configured');

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -5,7 +5,7 @@
  */
 
 import { Command, Option } from 'clipanion';
-import { colors } from '../onboarding/index.js';
+import { colors, spinner } from '../onboarding/index.js';
 import { createTeamManager, createSkillBundle, exportBundle, importBundle } from '@skillkit/core';
 import { join } from 'node:path';
 
@@ -82,10 +82,13 @@ export class TeamCommand extends Command {
       return 1;
     }
 
+    const s = spinner();
+    s.start('Initializing team');
     const config = await teamManager.init({
       teamName: this.name,
       registryUrl: this.registry,
     });
+    s.stop('Team initialized');
 
     this.context.stdout.write(colors.success('✓ Team initialized!\n'));
     this.context.stdout.write(`  Team ID: ${config.teamId}\n`);
@@ -105,11 +108,14 @@ export class TeamCommand extends Command {
       return 1;
     }
 
+    const s = spinner();
+    s.start('Sharing skill');
     const shared = await teamManager.shareSkill({
       skillName: this.name,
       description: this.description,
       tags: this.tags?.split(',').map((t) => t.trim()),
     });
+    s.stop('Skill shared');
 
     this.context.stdout.write(colors.success('✓ Skill shared!\n'));
     this.context.stdout.write(`  Name: ${shared.name}\n`);
@@ -130,10 +136,13 @@ export class TeamCommand extends Command {
       return 1;
     }
 
+    const s = spinner();
+    s.start('Importing skill');
     const result = await teamManager.importSkill(this.name, {
       overwrite: this.overwrite,
       dryRun: this.dryRun,
     });
+    s.stop('Import complete');
 
     if (!result.success) {
       this.context.stderr.write(colors.error(`✗ ${result.error}\n`));
@@ -184,9 +193,11 @@ export class TeamCommand extends Command {
       return 1;
     }
 
-    this.context.stdout.write(`Syncing with ${config.registryUrl}...\n`);
+    const s = spinner();
+    s.start(`Syncing with ${config.registryUrl}`);
 
     const result = await teamManager.sync();
+    s.stop('Sync complete');
 
     this.context.stdout.write(colors.success('✓ Sync complete!\n'));
     if (result.added.length > 0) {
@@ -335,7 +346,10 @@ export class TeamCommand extends Command {
       return 0;
     }
 
+    const s = spinner();
+    s.start('Importing bundle');
     const result = importBundle(this.source, skillsDir, { overwrite: this.overwrite });
+    s.stop('Import complete');
 
     if (!result.success && result.imported.length === 0) {
       this.context.stderr.write(colors.error('✗ Failed to import bundle:\n'));

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from 'clipanion';
 import { resolve, join } from 'node:path';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { colors, warn, success, error, step } from '../onboarding/index.js';
+import { colors, warn, success, error, step, spinner } from '../onboarding/index.js';
 import {
   runTestSuite,
   createTestSuiteFromFrontmatter,
@@ -105,16 +105,16 @@ export class TestCommand extends Command {
       return 1;
     }
 
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
+
     if (!this.json) {
       console.log(colors.bold('Running skill tests...\n'));
     }
 
-    // Parse tags
     const tags = this.tags?.split(',').map((t) => t.trim());
     const skipTags = this.skipTags?.split(',').map((t) => t.trim());
     const timeout = this.timeout ? parseInt(this.timeout, 10) : undefined;
 
-    // Run tests for each skill
     const results: TestSuiteResult[] = [];
     let allPassed = true;
 
@@ -128,6 +128,7 @@ export class TestCommand extends Command {
       if (!this.json) {
         step(`Testing: ${suite.skillName}`);
       }
+      s.start(`Running ${suite.skillName}`);
 
       const result = await runTestSuite(suite, {
         cwd: targetPath,
@@ -162,6 +163,7 @@ export class TestCommand extends Command {
         },
       });
 
+      s.stop(`Completed ${suite.skillName}`);
       results.push(result);
 
       if (!result.passed) {

--- a/packages/cli/src/commands/translate.ts
+++ b/packages/cli/src/commands/translate.ts
@@ -89,6 +89,10 @@ export class TranslateCommand extends Command {
     description: 'Show compatibility info between agents',
   });
 
+  json = Option.Boolean('--json', false, {
+    description: 'Output as JSON',
+  });
+
   async execute(): Promise<number> {
     // List supported agents
     if (this.list) {
@@ -218,15 +222,21 @@ export class TranslateCommand extends Command {
     const skills = findAllSkills(searchDirs);
 
     if (skills.length === 0) {
-      warn('No skills found to translate');
+      if (this.json) {
+        console.log(JSON.stringify({ success: true, translated: 0, agent: targetAgent }));
+      } else {
+        warn('No skills found to translate');
+      }
       return 0;
     }
 
-    console.log(colors.bold(`\nTranslating ${skills.length} skill(s) to ${targetAgent}...\n`));
+    if (!this.json) {
+      console.log(colors.bold(`\nTranslating ${skills.length} skill(s) to ${targetAgent}...\n`));
+    }
 
     let successCount = 0;
     let failed = 0;
-    const s = spinner();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
 
     for (const skill of skills) {
       const skillMdPath = join(skill.path, 'SKILL.md');
@@ -289,8 +299,12 @@ export class TranslateCommand extends Command {
       }
     }
 
-    console.log();
-    console.log(colors.bold(`Translated: ${successCount}, Failed: ${failed}`));
+    if (this.json) {
+      console.log(JSON.stringify({ success: failed === 0, translated: successCount, agent: targetAgent }));
+    } else {
+      console.log();
+      console.log(colors.bold(`Translated: ${successCount}, Failed: ${failed}`));
+    }
 
     return failed > 0 ? 1 : 0;
   }
@@ -336,8 +350,7 @@ export class TranslateCommand extends Command {
       }
     }
 
-    // Read and translate
-    const s = spinner();
+    const s = this.json ? { start: () => {}, stop: () => {}, message: () => {} } : spinner();
     s.start(`Translating to ${targetAgent}...`);
 
     const content = readFileSync(sourcePath!, 'utf-8');
@@ -349,39 +362,45 @@ export class TranslateCommand extends Command {
     s.stop(`Translation complete`);
 
     if (!result.success) {
-      error('Translation failed:');
-      for (const item of result.incompatible) {
-        console.log(colors.muted(`  ${item}`));
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, translated: 0, agent: targetAgent }));
+      } else {
+        error('Translation failed:');
+        for (const item of result.incompatible) {
+          console.log(colors.muted(`  ${item}`));
+        }
       }
       return 1;
     }
 
-    // Show warnings
-    if (result.warnings.length > 0) {
-      warn('\nWarnings:');
-      for (const warning of result.warnings) {
-        console.log(colors.warning(`  • ${warning}`));
+    if (!this.json) {
+      if (result.warnings.length > 0) {
+        warn('\nWarnings:');
+        for (const warning of result.warnings) {
+          console.log(colors.warning(`  • ${warning}`));
+        }
+      }
+
+      if (result.incompatible.length > 0) {
+        console.log(colors.muted('\nIncompatible features:'));
+        for (const item of result.incompatible) {
+          console.log(colors.muted(`  • ${item}`));
+        }
       }
     }
 
-    // Show incompatible features
-    if (result.incompatible.length > 0) {
-      console.log(colors.muted('\nIncompatible features:'));
-      for (const item of result.incompatible) {
-        console.log(colors.muted(`  • ${item}`));
-      }
-    }
-
-    // Dry run - just show preview
     if (this.dryRun) {
-      console.log(colors.bold(`\nTranslated content (${result.filename}):\n`));
-      console.log(colors.muted('─'.repeat(60)));
-      console.log(result.content);
-      console.log(colors.muted('─'.repeat(60)));
+      if (this.json) {
+        console.log(JSON.stringify({ success: true, translated: 1, agent: targetAgent }));
+      } else {
+        console.log(colors.bold(`\nTranslated content (${result.filename}):\n`));
+        console.log(colors.muted('─'.repeat(60)));
+        console.log(result.content);
+        console.log(colors.muted('─'.repeat(60)));
+      }
       return 0;
     }
 
-    // Determine output path
     let outputPath: string;
     if (this.output) {
       outputPath = this.output;
@@ -396,14 +415,16 @@ export class TranslateCommand extends Command {
       outputPath = join(outputDir, result.filename);
     }
 
-    // Check for existing file
     if (existsSync(outputPath) && !this.force) {
-      error(`${outputPath} already exists`);
-      console.log(colors.muted('Use --force to overwrite'));
+      if (this.json) {
+        console.log(JSON.stringify({ success: false, error: `${outputPath} already exists` }));
+      } else {
+        error(`${outputPath} already exists`);
+        console.log(colors.muted('Use --force to overwrite'));
+      }
       return 1;
     }
 
-    // Write output
     const outputDir = dirname(outputPath);
     if (!existsSync(outputDir)) {
       mkdirSync(outputDir, { recursive: true });
@@ -411,9 +432,13 @@ export class TranslateCommand extends Command {
 
     writeFileSync(outputPath, result.content, 'utf-8');
 
-    success(`\n✓ Translated to ${outputPath}`);
-    console.log(colors.muted(`  Format: ${result.targetFormat}`));
-    console.log(colors.muted(`  Agent: ${result.targetAgent}`));
+    if (this.json) {
+      console.log(JSON.stringify({ success: true, translated: 1, agent: targetAgent }));
+    } else {
+      success(`\n✓ Translated to ${outputPath}`);
+      console.log(colors.muted(`  Format: ${result.targetFormat}`));
+      console.log(colors.muted(`  Agent: ${result.targetAgent}`));
+    }
 
     return 0;
   }


### PR DESCRIPTION
## Summary

Completes #89 and #88 — all CLI commands now have `--json` output and loading spinners.

### --json added to 9 more commands
create, enable/disable, eval, sync, tap (add/remove/list), translate, save, read

### Spinners added to 8 more commands
audit, fix, test, plugin, team, methodology, hook, remove

### Total coverage
- **--json**: 47 of 50 commands (excluding ui, serve, init which are interactive-only)
- **Spinners**: 29 commands with I/O operations

All JSON paths use no-op spinners to prevent stdout pollution.

## Test plan
- [x] `pnpm build` — 13/13
- [x] `pnpm test` — all pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag to many CLI commands for structured machine-readable output.
  * Integrated interactive progress spinners and stage-specific status messages across CLI commands for clearer feedback during long-running operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->