### PR TITLE
chore(release): v1.23.0 — slim install, safer picker, branded tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,107 +3,227 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/img/banner.svg">
   <source media="(prefers-color-scheme: light)" srcset="docs/img/banner.svg">
-  <img alt="SkillKit - One Skill. Every Agent." src="docs/img/banner.svg" width="100%">
+  <img alt="SkillKit. One skill. Every agent." src="docs/img/banner.svg" width="100%">
 </picture>
 
 <br/>
+
+### *One skill. Every agent. 45 of them.*
+
 <br/>
 
-[![CI](https://github.com/rohitg00/skillkit/actions/workflows/ci.yml/badge.svg)](https://github.com/rohitg00/skillkit/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/skillkit.svg?style=flat-square&color=3b82f6)](https://www.npmjs.com/package/skillkit)
-[![npm downloads](https://img.shields.io/npm/dm/skillkit.svg?style=flat-square)](https://www.npmjs.com/package/skillkit)
-[![GitHub stars](https://img.shields.io/github/stars/rohitg00/skillkit?style=flat-square)](https://github.com/rohitg00/skillkit/stargazers)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+[![npm](https://img.shields.io/npm/v/skillkit?style=for-the-badge&logo=npm&logoColor=white&labelColor=0D1117&color=CB3837)](https://www.npmjs.com/package/skillkit)
+[![downloads](https://img.shields.io/npm/dm/skillkit?style=for-the-badge&logo=npm&logoColor=white&labelColor=0D1117&color=FF8B94)](https://www.npmjs.com/package/skillkit)
+[![stars](https://img.shields.io/github/stars/rohitg00/skillkit?style=for-the-badge&logo=github&logoColor=white&labelColor=0D1117&color=FFC75F)](https://github.com/rohitg00/skillkit/stargazers)
+[![CI](https://img.shields.io/github/actions/workflow/status/rohitg00/skillkit/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white&labelColor=0D1117&color=6BCB77)](https://github.com/rohitg00/skillkit/actions/workflows/ci.yml)
+[![license](https://img.shields.io/badge/License-Apache_2.0-4D96FF?style=for-the-badge&labelColor=0D1117)](LICENSE)
 
-**SkillKit** is the open source package manager for AI agent skills. Write a skill once, deploy it to **45 agents** — Claude, Cursor, Copilot, Windsurf, Devin, Codex, and 39 more. No rewrites. 400K+ skills across registries.
+<br/>
 
-[Website](https://skillkit.sh) &middot; [Docs](https://skillkit.sh/docs) &middot; [API Explorer](https://skillkit.sh/api) &middot; [Chrome Extension](https://github.com/rohitg00/skillkit/tree/main/packages/extension#readme) &middot; [npm](https://www.npmjs.com/package/skillkit)
+<a href="https://skillkit.sh"><img src="assets/tags/skills.svg" alt="400K+ skills"></a>
+<a href="#supported-agents"><img src="assets/tags/agents.svg" alt="45 agents"></a>
+<a href="#skill-sources"><img src="assets/tags/sources.svg" alt="31 sources"></a>
+<img src="assets/tags/tests.svg" alt="757 tests">
+<a href="LICENSE"><img src="assets/tags/license.svg" alt="Apache 2.0"></a>
+<a href="CONTRIBUTING.md"><img src="assets/tags/prs-welcome.svg" alt="PRs welcome"></a>
+
+<br/>
+
+<a href="#full-vs-slim"><img src="assets/tags/slim-install.svg" alt="slim install"></a>
+<a href="https://github.com/rohitg00/skillkit/releases/latest"><img src="assets/tags/v1.23.0.svg" alt="v1.23.0"></a>
+<img src="assets/tags/new.svg" alt="new">
+<img src="assets/tags/one-skill.svg" alt="one skill">
+<img src="assets/tags/every-agent.svg" alt="every agent">
+
+<sub>Tags are SVGs under <a href="assets/tags/"><code>/assets/tags/</code></a>. Fork and remix.</sub>
+
+<br/>
+
+### Quick nav
+
+[**Quick start**](#quick-start) · [**Install**](#install) · [**Commands**](#commands) · [**Agents**](#supported-agents) · [**Sources**](#skill-sources) · [**API**](#programmatic-api) · [**Website**](https://skillkit.sh)
 
 </div>
 
 ---
-https://github.com/user-attachments/assets/b1843a07-2c54-422d-8903-f30a790cfb37
-
-Skills make AI coding agents smarter. But every agent uses a different format:
-
-| Agent | Format | Directory |
-|-------|--------|-----------|
-| Claude Code | `SKILL.md` | `.claude/skills/` |
-| Cursor | `.mdc` | `.cursor/skills/` |
-| Copilot | Markdown | `.github/skills/` |
-| Windsurf | Markdown | `.windsurf/skills/` |
-
-You end up rewriting the same skill for each agent, or locking into one platform.
-
-**SkillKit fixes this.** Install from 400K+ skills across registries, auto-translate between formats, persist learnings with Memory. Works with Claude, Cursor, Windsurf, Copilot, and 41 more.
-
-```bash
-npx skillkit@latest
-```
-
-## See It In Action
 
 <div align="center">
 
-![SkillKit vs skills CLI](docs/img/inital-command.png)
+https://github.com/user-attachments/assets/b1843a07-2c54-422d-8903-f30a790cfb37
 
 </div>
 
-> **New in v1.20.0:** Live download progress, sparse checkout for monorepos (~1.4s for large repos), and `skillkit remove --source` to bulk-remove by repo.
+## The problem
 
-## Quick Start
+Every AI coding agent wants skills. Every agent invented a different format.
+
+<table>
+<tr>
+<th>Agent</th>
+<th>Format</th>
+<th>Directory</th>
+</tr>
+<tr><td>Claude Code</td><td><code>SKILL.md</code></td><td><code>.claude/skills/</code></td></tr>
+<tr><td>Cursor</td><td><code>.mdc</code></td><td><code>.cursor/skills/</code></td></tr>
+<tr><td>Copilot</td><td>Markdown</td><td><code>.github/skills/</code></td></tr>
+<tr><td>Windsurf</td><td>Markdown</td><td><code>.windsurf/skills/</code></td></tr>
+<tr><td colspan="3"><i>... 41 more</i></td></tr>
+</table>
+
+You rewrite the same skill for each agent. Or you lock in to one.
+
+## The fix
+
+SkillKit is the package manager for AI agent skills. Install from 400K+ skills across 31 sources. Auto-translate between formats. Persist session learnings. Ship to 45 agents at once.
 
 ```bash
-npx skillkit@latest init              # Detect agents, create dirs
-skillkit recommend                    # Get smart suggestions
-skillkit install anthropics/skills    # Install from marketplace
-skillkit sync                         # Deploy to your agents
+npx skillkit add anthropics/skills
 ```
 
-Four commands. Your agents now have skills for PDF processing, code review, and more.
+That is the whole first-run. Pick your agent (your detected agent is pre-selected), confirm, done.
 
-## What Can You Do?
-
-### Install skills from anywhere
+## Quick start
 
 ```bash
-skillkit install anthropics/skills          # GitHub
-skillkit install gitlab:team/skills         # GitLab
-skillkit install ./my-local-skills          # Local path
+npx skillkit init                     # detect agent, create dirs
+skillkit recommend                    # stack-aware suggestions
+skillkit add anthropics/skills        # install from marketplace
+skillkit sync                         # deploy to agent config
 ```
 
-### Translate between agents
+Four commands. Your agent now has PDF processing, code review, auth patterns, and whatever you need.
 
-Write for Claude, deploy to Cursor:
+### What the first install looks like
+
+```
+$ npx skillkit add anthropics/skills
+
+ ◇ Detected 32 agents
+ │
+ ◆ Install to
+ │  ● Just Claude Code (detected)      claude-code
+ │  ○ Select specific agents           space to toggle
+ │  ○ All supported agents             32 agents, writes to every adapter
+ └
+
+ ◇ Cloning anthropics/skills
+ ◇ Security scan: 42/42 skills pass
+ ◇ Installed 42 skills to Claude Code
+ │
+ └ Done in 3.1s. Run `skillkit list` to see them.
+```
+
+## Install
+
+Pick one. All three do the same thing.
+
+```bash
+npm install -g skillkit       # npm
+pnpm add -g skillkit          # pnpm
+bun add -g skillkit           # bun
+```
+
+Both `skillkit` and `sk` work as the binary name.
+
+### Full vs slim
+
+Four features ship as optional packages so a bare CLI stays small. The default install pulls everything. Add `--omit=optional` if you only want the core.
+
+| Feature         | Package                | Command          |
+| :-------------- | :--------------------- | :--------------- |
+| Terminal UI     | `@skillkit/tui`        | `skillkit ui`    |
+| REST server     | `@skillkit/api`        | `skillkit serve` |
+| Peer mesh       | `@skillkit/mesh`       | `skillkit mesh`  |
+| Agent messaging | `@skillkit/messaging`  | `skillkit message` |
+
+Cold install numbers on a fresh npm cache:
+
+<p align="center">
+  <img src="assets/tags/packages.svg" alt="118 packages">
+  <img src="assets/tags/install.svg" alt="9s install">
+  <img src="assets/tags/vulns.svg" alt="0 vulnerabilities">
+</p>
+
+| Mode                                | Packages | Time | Vulns (crit/high) |
+| :---------------------------------- | -------: | :--: | ----------------: |
+| `npm i -g skillkit`                 |      418 |  18s |               0/0 |
+| `npm i -g skillkit --omit=optional` |      118 |   9s |               0/0 |
+
+Skipped optional? Add just the one you want later:
+
+```bash
+npm i -g @skillkit/tui         # enables: skillkit ui
+npm i -g @skillkit/api         # enables: skillkit serve
+npm i -g @skillkit/mesh        # enables: skillkit mesh
+npm i -g @skillkit/messaging   # enables: skillkit message
+```
+
+The CLI catches missing optional packages and prints a one-line hint. No stack trace.
+
+### Using `npx`
+
+`npx skillkit add <owner/repo>` works with zero install. First call caches the package under `~/.npm/_npx/`. Every run after that is instant until a new version ships.
+
+```bash
+npx skillkit add anthropics/skills                    # full
+npx --omit=optional skillkit add anthropics/skills    # slim
+```
+
+If you reach for `npx skillkit` more than twice, switch to a global install. Kills the prompt-to-proceed and the per-release refetch.
+
+## What you can do
+
+<details open>
+<summary><b>Install from anywhere</b></summary>
+
+```bash
+skillkit add anthropics/skills           # GitHub
+skillkit add gitlab:team/skills          # GitLab
+skillkit add ./my-local-skills           # local path
+skillkit add https://gist.github.com/... # gist
+```
+</details>
+
+<details>
+<summary><b>Translate between agents</b></summary>
+
+Write once for Claude, ship everywhere:
 
 ```bash
 skillkit translate my-skill --to cursor
-skillkit translate --all --to windsurf
+skillkit translate --all --to windsurf,codex
+skillkit translate my-skill --to copilot --dry-run
 ```
+</details>
 
-### Get smart recommendations
+<details>
+<summary><b>Stack-aware recommendations</b></summary>
 
-SkillKit reads your project, detects your stack, and suggests relevant skills:
+SkillKit reads your repo, spots your stack, ranks skills:
 
 ```bash
-skillkit recommend
-# 92% vercel-react-best-practices
-# 87% tailwind-v4-patterns
-# 85% nextjs-app-router
+$ skillkit recommend
+
+  92% vercel-react-best-practices
+  87% tailwind-v4-patterns
+  85% nextjs-app-router
+  81% shadcn-ui-components
 ```
+</details>
 
-### Discover skills at runtime
+<details>
+<summary><b>Runtime skill discovery (REST)</b></summary>
 
-Start an API server and let agents find skills on demand:
+Start the server, let agents fetch skills on demand:
 
 ```bash
 skillkit serve
-# Server running at http://localhost:3737
+# http://localhost:3737
 
 curl "http://localhost:3737/search?q=react+performance"
 ```
 
-Or use MCP for native agent integration:
+Or wire it up with MCP:
 
 ```json
 {
@@ -113,11 +233,7 @@ Or use MCP for native agent integration:
 }
 ```
 
-Or use Python:
-
-```bash
-pip install skillkit-client
-```
+Or call from Python:
 
 ```python
 from skillkit import SkillKitClient
@@ -126,53 +242,47 @@ async with SkillKitClient() as client:
     results = await client.search("react performance", limit=5)
 ```
 
-[REST API docs](https://skillkit.sh/docs/rest-api) &middot; [MCP Server docs](https://skillkit.sh/docs/mcp-server) &middot; [Python Client docs](https://skillkit.sh/docs/python-client) &middot; [Interactive API explorer](https://skillkit.sh/api)
+[REST docs](https://skillkit.sh/docs/rest-api) · [MCP docs](https://skillkit.sh/docs/mcp-server) · [Python client](https://skillkit.sh/docs/python-client)
+</details>
 
-### Auto-generate agent instructions
+<details>
+<summary><b>Auto-generate agent instructions</b></summary>
 
-Let SkillKit analyze your codebase and create CLAUDE.md, .cursorrules, etc.:
+Analyze the codebase and write CLAUDE.md, `.cursorrules`, AGENTS.md, and friends:
 
 ```bash
 skillkit primer --all-agents
 ```
+</details>
 
-### Session memory
+<details>
+<summary><b>Session memory</b></summary>
 
-Your AI agents learn patterns during sessions, then forget everything. SkillKit captures those learnings:
+AI agents learn during a session, then forget. SkillKit captures what they learned:
 
 ```bash
 skillkit memory compress
 skillkit memory search "auth patterns"
 skillkit memory export auth-patterns
 ```
+</details>
 
-### AI skill generation
+<details>
+<summary><b>AI skill generation</b></summary>
 
-Generate skills from natural language with multi-source context:
+Generate skills from plain English with multi-source context:
 
 ```bash
 skillkit generate
-# Interactive wizard with 4 context sources:
-# - Documentation (via Context7)
-# - Your codebase patterns
-# - 400K+ marketplace skills
-# - Memory (your corrections)
 ```
 
-Works with any LLM: Claude, GPT-4, Gemini, Ollama (local), or OpenRouter (100+ models). Generates agent-optimized variants with trust scores.
+Pulls context from four places: Context7 docs, your codebase, 400K marketplace skills, your memory. Works with Claude, GPT-4, Gemini, Ollama (local), or any OpenRouter model.
+</details>
 
-### Mesh network
+<details>
+<summary><b>Team collaboration</b></summary>
 
-Distribute agents across machines with encrypted P2P:
-
-```bash
-skillkit mesh init
-skillkit mesh discover
-```
-
-### Team collaboration
-
-Share skills via a Git-committable `.skills` manifest:
+Share skills via a committable `.skills` manifest:
 
 ```bash
 skillkit manifest init
@@ -180,125 +290,156 @@ skillkit manifest add anthropics/skills
 git commit -m "add team skills"
 ```
 
-Team members run `skillkit manifest install` and they're in sync.
+Everyone else runs `skillkit manifest install` and matches state.
+</details>
 
-### Chrome Extension
+<details>
+<summary><b>Mesh network</b></summary>
 
-Save any webpage as a skill directly from your browser.
+Distribute agents across machines with encrypted P2P:
 
-1. Build: `pnpm --filter @skillkit/extension build`
-2. Chrome → `chrome://extensions` → Load unpacked → `packages/extension/dist/`
-3. Click the extension icon or right-click → "Save page as Skill"
+```bash
+skillkit mesh init
+skillkit mesh discover
+```
+</details>
 
-The extension sends the page URL to the SkillKit API for server-side extraction with Turndown, 5-source weighted tag detection, and GitHub URL support. The resulting SKILL.md downloads automatically. Then run `skillkit install ~/Downloads/skillkit-skills/my-skill` to deploy to all agents.
+<details>
+<summary><b>Chrome extension</b></summary>
+
+Save any webpage as a skill from the browser. Click the extension, the page round-trips through the SkillKit API (Turndown, 5-source tag detection, GitHub URL support), the `SKILL.md` downloads, then run `skillkit add ~/Downloads/skillkit-skills/<name>`.
 
 [Extension docs](https://skillkit.sh/docs/chrome-extension)
+</details>
 
-### Interactive TUI
+<details>
+<summary><b>Interactive TUI</b></summary>
 
 ```bash
 skillkit ui
 ```
 
-`h` Home &middot; `m` Marketplace &middot; `r` Recommend &middot; `t` Translate &middot; `i` Installed &middot; `s` Sync &middot; `q` Quit
+<sub><code>h</code> home · <code>m</code> marketplace · <code>r</code> recommend · <code>t</code> translate · <code>i</code> installed · <code>s</code> sync · <code>q</code> quit</sub>
 
-![SkillKit Interactive CLI](docs/img/inital-command.png)
+<img src="docs/img/skillkit-ui.png" width="100%" alt="SkillKit interactive TUI">
 
-## Supported Agents (45)
-
-| Agent | Format | Directory |
-|-------|--------|-----------|
-| **Claude Code** | SKILL.md | `.claude/skills/` |
-| **Cursor** | .mdc | `.cursor/skills/` |
-| **Codex** | SKILL.md | `.codex/skills/` |
-| **Gemini CLI** | SKILL.md | `.gemini/skills/` |
-| **OpenCode** | SKILL.md | `.opencode/skills/` |
-| **GitHub Copilot** | Markdown | `.github/skills/` |
-| **Windsurf** | Markdown | `.windsurf/skills/` |
-| **Devin** | Markdown | `.devin/skills/` |
-| **Aider** | SKILL.md | `.aider/skills/` |
-| **Sourcegraph Cody** | SKILL.md | `.cody/skills/` |
-| **Amazon Q** | SKILL.md | `.amazonq/skills/` |
-
-Plus 34 more: Amp, Antigravity, Augment Code, Bolt, Clawdbot, Cline, CodeBuddy, CodeGPT, CommandCode, Continue, Crush, Droid, Factory, Goose, Kilo Code, Kiro CLI, Lovable, MCPJam, Mux, Neovate, OpenClaw, OpenHands, Pi, PlayCode, Qoder, Qwen, Replit Agent, Roo Code, Tabby, Tabnine, Trae, Vercel, Zencoder, Universal
-
-[Full agent details](https://skillkit.sh/docs/agents)
+</details>
 
 ## Commands
 
-### Core
+<details open>
+<summary><b>Core</b></summary>
 
 ```bash
-skillkit install <source>        # Install skills (with live progress)
-skillkit remove <skills>         # Remove skills
-skillkit remove --source org/repo # Remove all skills from a source
-skillkit remove --all            # Remove all installed skills
-skillkit update                  # Update skills (with change detection)
-skillkit check                   # Check for updates, quality, and activity
-skillkit translate <skill> --to  # Translate between agents
-skillkit sync                    # Deploy to agent config
-skillkit recommend               # Smart recommendations
-skillkit generate                # AI skill generation wizard
-skillkit serve                   # Start REST API server
-skillkit publish submit          # Publish to marketplace via CLI
+skillkit add <source>            # install skills (live progress)
+skillkit remove <skills>         # remove
+skillkit remove --source org/repo # bulk by source
+skillkit remove --all            # remove everything
+skillkit update                  # update (change detection)
+skillkit check                   # updates, quality, activity
+skillkit translate <skill> --to  # agent format conversion
+skillkit sync                    # deploy to agent config
+skillkit recommend               # smart recommendations
+skillkit generate                # AI skill wizard
+skillkit serve                   # REST API server
+skillkit publish submit          # publish to marketplace
 ```
+</details>
 
-### Discovery & Security
+<details>
+<summary><b>Discovery & security</b></summary>
 
 ```bash
-skillkit marketplace             # Browse skills
-skillkit tree                    # Hierarchical taxonomy
-skillkit find <query>            # Quick search
-skillkit scan <path>             # Security scan for skills
+skillkit marketplace             # browse
+skillkit tree                    # taxonomy
+skillkit find <query>            # quick search
+skillkit scan <path>             # security scan
 ```
+</details>
 
-### Custom Sources
+<details>
+<summary><b>Custom sources</b></summary>
 
 ```bash
-skillkit tap add owner/repo      # Add custom skill source
-skillkit tap list                # List custom sources
-skillkit tap remove owner/repo   # Remove custom source
+skillkit tap add owner/repo
+skillkit tap list
+skillkit tap remove owner/repo
 ```
+</details>
 
-### Issue Planner
+<details>
+<summary><b>Issue planner</b></summary>
 
 ```bash
-skillkit issue plan "#42"        # Plan from GitHub Issue
-skillkit issue plan owner/repo#42 # Cross-repo plan
-skillkit issue list              # List open issues
+skillkit issue plan "#42"
+skillkit issue plan owner/repo#42
+skillkit issue list
 ```
+</details>
 
-### Session Intelligence
+<details>
+<summary><b>Session intelligence</b></summary>
 
 ```bash
-skillkit timeline                # Unified event stream
-skillkit session handoff         # Agent-to-agent context
-skillkit lineage                 # Skill impact graph
-skillkit session explain         # Human-readable summary
-skillkit activity                # Skill activity log
+skillkit timeline                # unified event stream
+skillkit session handoff         # agent-to-agent context
+skillkit lineage                 # skill impact graph
+skillkit session explain         # human summary
+skillkit activity                # activity log
 ```
+</details>
 
-### Advanced
+<details>
+<summary><b>Advanced</b></summary>
 
 ```bash
-skillkit primer --all-agents     # Generate agent instructions
-skillkit memory compress         # Capture session learnings
-skillkit mesh init               # Multi-machine distribution
-skillkit message send            # Inter-agent messaging
-skillkit workflow run <name>     # Run workflows
-skillkit test                    # Test skills
+skillkit primer --all-agents     # agent instruction files
+skillkit memory compress         # capture session learnings
+skillkit mesh init               # multi-machine distribution
+skillkit message send            # inter-agent messaging
+skillkit workflow run <name>     # run workflows
+skillkit test                    # test skills
 skillkit cicd init               # CI/CD templates
 ```
+</details>
 
 [Full command reference](https://skillkit.sh/docs/commands)
 
-## Creating Skills
+## Supported agents
+
+<details open>
+<summary><b>Top 11</b></summary>
+
+| Agent              | Format     | Directory          |
+| :----------------- | :--------- | :----------------- |
+| **Claude Code**    | `SKILL.md` | `.claude/skills/`  |
+| **Cursor**         | `.mdc`     | `.cursor/skills/`  |
+| **Codex**          | `SKILL.md` | `.codex/skills/`   |
+| **Gemini CLI**     | `SKILL.md` | `.gemini/skills/`  |
+| **OpenCode**       | `SKILL.md` | `.opencode/skills/`|
+| **GitHub Copilot** | Markdown   | `.github/skills/`  |
+| **Windsurf**       | Markdown   | `.windsurf/skills/`|
+| **Devin**          | Markdown   | `.devin/skills/`   |
+| **Aider**          | `SKILL.md` | `.aider/skills/`   |
+| **Cody**           | `SKILL.md` | `.cody/skills/`    |
+| **Amazon Q**       | `SKILL.md` | `.amazonq/skills/` |
+</details>
+
+<details>
+<summary><b>Plus 34 more</b></summary>
+
+Amp, Antigravity, Augment Code, Bolt, Clawdbot, Cline, CodeBuddy, CodeGPT, CommandCode, Continue, Crush, Droid, Factory, Goose, Kilo Code, Kiro CLI, Lovable, MCPJam, Mux, Neovate, OpenClaw, OpenHands, Pi, PlayCode, Qoder, Qwen, Replit Agent, Roo Code, Tabby, Tabnine, Trae, Vercel, Zencoder, Universal.
+</details>
+
+[Full agent details](https://skillkit.sh/docs/agents)
+
+## Creating skills
 
 ```bash
 skillkit create my-skill
 ```
 
-Or manually create a `SKILL.md`:
+Or author a `SKILL.md` by hand:
 
 ```markdown
 ---
@@ -309,20 +450,20 @@ license: MIT
 
 # My Skill
 
-Instructions for the AI agent.
+Instructions for the agent.
 
-## When to Use
-- Scenario 1
-- Scenario 2
+## When to use
+- scenario 1
+- scenario 2
 
 ## Steps
-1. First step
-2. Second step
+1. first
+2. second
 ```
 
 ## Programmatic API
 
-```typescript
+```ts
 import { translateSkill, analyzeProject, RecommendationEngine } from 'skillkit';
 
 const skill = await translateSkill(content, 'cursor');
@@ -332,114 +473,53 @@ const engine = new RecommendationEngine();
 const recs = await engine.recommend(profile);
 ```
 
-```typescript
+```ts
 import { startServer } from '@skillkit/api';
 await startServer({ port: 3737, skills: [...] });
 ```
 
-```typescript
+```ts
 import { MemoryCache, RelevanceRanker } from '@skillkit/core';
 const cache = new MemoryCache({ maxSize: 500, ttlMs: 86_400_000 });
 const ranker = new RelevanceRanker();
 const results = ranker.rank(skills, 'react performance');
 ```
 
-## Skill Sources
+## Skill sources
 
-SkillKit aggregates skills from trusted sources. All original creators are credited with their licenses preserved.
+All original creators credited. Licenses preserved. PRs welcome.
 
-### Official Partners
+### Official partners
 
-| Repository | Description |
-|------------|-------------|
+| Repository | What |
+|:-----------|:-----|
 | [anthropics/skills](https://github.com/anthropics/skills) | Official Claude Code skills |
-| [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills) | Next.js and React skills |
-| [expo/skills](https://github.com/expo/skills) | Mobile development with Expo |
-| [remotion-dev/skills](https://github.com/remotion-dev/skills) | Programmatic video creation |
-| [supabase/agent-skills](https://github.com/supabase/agent-skills) | Database and auth skills |
-| [stripe/ai](https://github.com/stripe/ai) | Payment integration patterns |
+| [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills) | Next.js, React |
+| [expo/skills](https://github.com/expo/skills) | Expo mobile |
+| [remotion-dev/skills](https://github.com/remotion-dev/skills) | Programmatic video |
+| [supabase/agent-skills](https://github.com/supabase/agent-skills) | Database, auth |
+| [stripe/ai](https://github.com/stripe/ai) | Payments |
 
 ### Community
 
-[trailofbits/skills](https://github.com/trailofbits/skills) &middot; [obra/superpowers](https://github.com/obra/superpowers) &middot; [wshobson/agents](https://github.com/wshobson/agents) &middot; [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) &middot; [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills) &middot; [langgenius/dify](https://github.com/langgenius/dify) &middot; [better-auth/skills](https://github.com/better-auth/skills) &middot; [onmax/nuxt-skills](https://github.com/onmax/nuxt-skills) &middot; [elysiajs/skills](https://github.com/elysiajs/skills) &middot; [kadajett/agent-nestjs-skills](https://github.com/kadajett/agent-nestjs-skills) &middot; [cloudai-x/threejs-skills](https://github.com/cloudai-x/threejs-skills) &middot; [dimillian/skills](https://github.com/dimillian/skills) &middot; [waynesutton/convexskills](https://github.com/waynesutton/convexskills) &middot; [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) &middot; [giuseppe-trisciuoglio/developer-kit](https://github.com/giuseppe-trisciuoglio/developer-kit) &middot; [openrouterteam/agent-skills](https://github.com/openrouterteam/agent-skills)
+[trailofbits/skills](https://github.com/trailofbits/skills) · [obra/superpowers](https://github.com/obra/superpowers) · [wshobson/agents](https://github.com/wshobson/agents) · [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) · [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills) · [langgenius/dify](https://github.com/langgenius/dify) · [better-auth/skills](https://github.com/better-auth/skills) · [onmax/nuxt-skills](https://github.com/onmax/nuxt-skills) · [elysiajs/skills](https://github.com/elysiajs/skills) · [kadajett/agent-nestjs-skills](https://github.com/kadajett/agent-nestjs-skills) · [cloudai-x/threejs-skills](https://github.com/cloudai-x/threejs-skills) · [dimillian/skills](https://github.com/dimillian/skills) · [waynesutton/convexskills](https://github.com/waynesutton/convexskills) · [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) · [giuseppe-trisciuoglio/developer-kit](https://github.com/giuseppe-trisciuoglio/developer-kit) · [openrouterteam/agent-skills](https://github.com/openrouterteam/agent-skills)
 
-**Want to add your skills?** [Submit your repository](https://github.com/rohitg00/skillkit/issues/new?template=add-source.md)
+**Want your skills listed?** [Submit your repo](https://github.com/rohitg00/skillkit/issues/new?template=add-source.md).
 
-## Install
+## Contributing
 
-```bash
-npm install -g skillkit       # npm
-pnpm add -g skillkit          # pnpm
-yarn global add skillkit      # yarn
-bun add -g skillkit           # bun
-npx skillkit <command>        # no install
-```
-
-### Install sizes
-
-Core commands — `install`, `list`, `find`, `translate`, `recommend`, `publish` —
-ship in the default package. Four power features are shipped as **optional
-dependencies** so a bare CLI install stays small:
-
-| Feature                  | Package              | Command                     |
-| ------------------------ | -------------------- | --------------------------- |
-| Interactive terminal UI  | `@skillkit/tui`      | `skillkit ui` / `skillkit tui` |
-| REST/OpenAPI server      | `@skillkit/api`      | `skillkit serve`            |
-| Peer mesh networking     | `@skillkit/mesh`     | `skillkit mesh …`           |
-| Inter-agent messaging    | `@skillkit/messaging`| `skillkit message …`        |
-
-```bash
-# Full install — every feature, everything works out of the box (default):
-npm install -g skillkit
-
-# Slim install — core commands only, ~75% smaller, no native addons:
-npm install -g skillkit --omit=optional
-pnpm add -g skillkit --prod --no-optional
-```
-
-Cold `npm install` measurements on a fresh cache:
-
-| Install mode          | Packages | Time | Deprecations |
-| --------------------- | -------- | ---- | ------------ |
-| `skillkit`            | 475      | 18 s | 3            |
-| `skillkit --omit=optional` | 118 | 9 s  | 0            |
-
-If you skipped optional deps and later want the UI, server, mesh, or
-messaging, add just the one you need:
-
-```bash
-npm install -g @skillkit/tui         # skillkit ui
-npm install -g @skillkit/api         # skillkit serve
-npm install -g @skillkit/mesh        # skillkit mesh
-npm install -g @skillkit/messaging   # skillkit message
-```
-
-### Using `npx` (no install)
-
-`npx skillkit add <owner/repo>` is the fastest way to try it. First run
-downloads the package into the npx cache (`~/.npm/_npx/`); every run
-after that is instant.
-
-```bash
-# Full (defaults to installing optional features):
-npx skillkit add anthropics/skills
-
-# Slim — core commands only, ~75% fewer packages, 0 warnings:
-npx --omit=optional skillkit add anthropics/skills
-```
-
-Run `npx skillkit` a few times and you will want the global install —
-it skips the prompt-to-proceed and kills the per-release cache refetch:
-
-```bash
-npm install -g skillkit --omit=optional   # 9 s, 118 packages, one time
-skillkit add anthropics/skills            # instant every run
-```
+Issues and PRs land fast. See [CONTRIBUTING.md](CONTRIBUTING.md) for the short version.
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE).
+Apache 2.0. See [LICENSE](LICENSE).
 
-## Links
+<br/>
 
-[Documentation](https://skillkit.sh/docs) &middot; [Website](https://skillkit.sh) &middot; [API Explorer](https://skillkit.sh/api) &middot; [npm](https://www.npmjs.com/package/skillkit) &middot; [GitHub](https://github.com/rohitg00/skillkit)
+<div align="center">
+
+[**Docs**](https://skillkit.sh/docs) · [**Website**](https://skillkit.sh) · [**API Explorer**](https://skillkit.sh/api) · [**npm**](https://www.npmjs.com/package/skillkit) · [**GitHub**](https://github.com/rohitg00/skillkit)
+
+<sub>Built for agents. Written by humans.</sub>
+
+</div>

--- a/apps/skillkit/package.json
+++ b/apps/skillkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillkit",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Supercharge AI coding agents with portable skills. Install, translate, and share skills across Claude Code, Cursor, Codex, Copilot & 41 more",
   "type": "module",
   "bin": {

--- a/assets/tags/agents.svg
+++ b/assets/tags/agents.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="84" height="28" viewBox="0 0 84 28" role="img">
+  <clipPath id="c"><rect width="84" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="56" height="28" fill="#18181b"/>
+    <rect x="56" width="28" height="28" fill="#09090b"/>
+    <rect x="0.5" y="0.5" width="83" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="28" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">agents</text>
+    <text x="70" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#fafafa" letter-spacing="0.3">45</text>
+  </g>
+</svg>

--- a/assets/tags/community.svg
+++ b/assets/tags/community.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="93" height="28" viewBox="0 0 93 28" role="img">
+  <rect x="0.5" y="0.5" width="92" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#a78bfa"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">community</text>
+</svg>

--- a/assets/tags/curated.svg
+++ b/assets/tags/curated.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="78" height="28" viewBox="0 0 78 28" role="img">
+  <rect x="0.5" y="0.5" width="77" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#06b6d4"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">curated</text>
+</svg>

--- a/assets/tags/deprecations.svg
+++ b/assets/tags/deprecations.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="119" height="28" viewBox="0 0 119 28" role="img">
+  <clipPath id="c"><rect width="119" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="98" height="28" fill="#18181b"/>
+    <rect x="98" width="21" height="28" fill="#22c55e"/>
+    <rect x="0.5" y="0.5" width="118" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="49" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">deprecations</text>
+    <text x="108.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#000" letter-spacing="0.3">0</text>
+  </g>
+</svg>

--- a/assets/tags/every-agent.svg
+++ b/assets/tags/every-agent.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="107" height="28" viewBox="0 0 107 28" role="img">
+  <rect x="0.5" y="0.5" width="106" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#3b82f6"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">every agent</text>
+</svg>

--- a/assets/tags/install.svg
+++ b/assets/tags/install.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="91" height="28" viewBox="0 0 91 28" role="img">
+  <clipPath id="c"><rect width="91" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="63" height="28" fill="#18181b"/>
+    <rect x="63" width="28" height="28" fill="#22c55e"/>
+    <rect x="0.5" y="0.5" width="90" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="31.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">install</text>
+    <text x="77" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#000" letter-spacing="0.3">9s</text>
+  </g>
+</svg>

--- a/assets/tags/license.svg
+++ b/assets/tags/license.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="147" height="28" viewBox="0 0 147 28" role="img">
+  <clipPath id="c"><rect width="147" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="63" height="28" fill="#18181b"/>
+    <rect x="63" width="84" height="28" fill="#09090b"/>
+    <rect x="0.5" y="0.5" width="146" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="31.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">license</text>
+    <text x="105" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#fafafa" letter-spacing="0.3">Apache-2.0</text>
+  </g>
+</svg>

--- a/assets/tags/new.svg
+++ b/assets/tags/new.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="28" viewBox="0 0 50 28" role="img">
+  <rect x="0.5" y="0.5" width="49" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#22c55e"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">new</text>
+</svg>

--- a/assets/tags/node.svg
+++ b/assets/tags/node.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="84" height="28" viewBox="0 0 84 28" role="img">
+  <clipPath id="c"><rect width="84" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="42" height="28" fill="#18181b"/>
+    <rect x="42" width="42" height="28" fill="#09090b"/>
+    <rect x="0.5" y="0.5" width="83" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="21" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">node</text>
+    <text x="63" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#fafafa" letter-spacing="0.3">>=18</text>
+  </g>
+</svg>

--- a/assets/tags/official.svg
+++ b/assets/tags/official.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="86" height="28" viewBox="0 0 86 28" role="img">
+  <rect x="0.5" y="0.5" width="85" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#f59e0b"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">official</text>
+</svg>

--- a/assets/tags/one-skill.svg
+++ b/assets/tags/one-skill.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="93" height="28" viewBox="0 0 93 28" role="img">
+  <rect x="0.5" y="0.5" width="92" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#3b82f6"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">one skill</text>
+</svg>

--- a/assets/tags/open-source.svg
+++ b/assets/tags/open-source.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="107" height="28" viewBox="0 0 107 28" role="img">
+  <rect x="0.5" y="0.5" width="106" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#f472b6"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">open source</text>
+</svg>

--- a/assets/tags/packages.svg
+++ b/assets/tags/packages.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="105" height="28" viewBox="0 0 105 28" role="img">
+  <clipPath id="c"><rect width="105" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="70" height="28" fill="#18181b"/>
+    <rect x="70" width="35" height="28" fill="#3b82f6"/>
+    <rect x="0.5" y="0.5" width="104" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="35" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">packages</text>
+    <text x="87.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#fff" letter-spacing="0.3">118</text>
+  </g>
+</svg>

--- a/assets/tags/prs-welcome.svg
+++ b/assets/tags/prs-welcome.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="107" height="28" viewBox="0 0 107 28" role="img">
+  <rect x="0.5" y="0.5" width="106" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#22c55e"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">PRs welcome</text>
+</svg>

--- a/assets/tags/skills.svg
+++ b/assets/tags/skills.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="105" height="28" viewBox="0 0 105 28" role="img">
+  <clipPath id="c"><rect width="105" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="56" height="28" fill="#18181b"/>
+    <rect x="56" width="49" height="28" fill="#09090b"/>
+    <rect x="0.5" y="0.5" width="104" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="28" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">skills</text>
+    <text x="80.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#fafafa" letter-spacing="0.3">400K+</text>
+  </g>
+</svg>

--- a/assets/tags/slim-install.svg
+++ b/assets/tags/slim-install.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="114" height="28" viewBox="0 0 114 28" role="img">
+  <rect x="0.5" y="0.5" width="113" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#3b82f6"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">slim install</text>
+</svg>

--- a/assets/tags/sources.svg
+++ b/assets/tags/sources.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="91" height="28" viewBox="0 0 91 28" role="img">
+  <clipPath id="c"><rect width="91" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="63" height="28" fill="#18181b"/>
+    <rect x="63" width="28" height="28" fill="#09090b"/>
+    <rect x="0.5" y="0.5" width="90" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="31.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">sources</text>
+    <text x="77" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#fafafa" letter-spacing="0.3">31</text>
+  </g>
+</svg>

--- a/assets/tags/tests.svg
+++ b/assets/tags/tests.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="84" height="28" viewBox="0 0 84 28" role="img">
+  <clipPath id="c"><rect width="84" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="49" height="28" fill="#18181b"/>
+    <rect x="49" width="35" height="28" fill="#09090b"/>
+    <rect x="0.5" y="0.5" width="83" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="24.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">tests</text>
+    <text x="66.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#fafafa" letter-spacing="0.3">757</text>
+  </g>
+</svg>

--- a/assets/tags/v1.23.0.svg
+++ b/assets/tags/v1.23.0.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="78" height="28" viewBox="0 0 78 28" role="img">
+  <rect x="0.5" y="0.5" width="77" height="27" rx="4" ry="4" fill="#09090b" stroke="#3f3f46"/>
+  <rect x="0" y="0" width="4" height="28" fill="#3b82f6"/>
+  <text x="18" y="18" text-anchor="start" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="600" fill="#fafafa" letter-spacing="0.3">v1.23.0</text>
+</svg>

--- a/assets/tags/vulns.svg
+++ b/assets/tags/vulns.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="70" height="28" viewBox="0 0 70 28" role="img">
+  <clipPath id="c"><rect width="70" height="28" rx="4" ry="4"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="49" height="28" fill="#18181b"/>
+    <rect x="49" width="21" height="28" fill="#22c55e"/>
+    <rect x="0.5" y="0.5" width="69" height="27" fill="none" stroke="#3f3f46" rx="4" ry="4"/>
+    <text x="24.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="500" fill="#a1a1aa" letter-spacing="0.3">vulns</text>
+    <text x="59.5" y="18" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" font-weight="700" fill="#000" letter-spacing="0.3">0</text>
+  </g>
+</svg>

--- a/docs/fumadocs/package.json
+++ b/docs/fumadocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillkit-docs",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/docs/skillkit/package.json
+++ b/docs/skillkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skillkit",
   "private": true,
-  "version": "1.22.1",
+  "version": "1.23.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillkit-monorepo",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "private": true,
   "description": "The package manager for AI agent skills — install, translate, share across 45 coding agents",
   "type": "module",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/agents",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Agent adapters for SkillKit - supports 45 AI coding agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/api",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "REST API server for SkillKit skill discovery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/cli",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "CLI commands for SkillKit",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/core",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Core functionality for SkillKit - skill discovery, parsing, and translation",
   "type": "module",
   "main": "./dist/index.js",
@@ -60,12 +60,8 @@
     "zod": "^3.24.1"
   },
   "optionalDependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
-    "@google/genai": "^1.0.0",
     "better-sqlite3": "^12.0.0",
     "node-llama-cpp": "^3.15.0",
-    "ollama": "^0.5.0",
-    "openai": "^4.0.0",
     "sqlite-vec": "^0.1.6"
   },
   "devDependencies": {

--- a/packages/mcp-memory/package.json
+++ b/packages/mcp-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/mcp-memory",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "MCP (Model Context Protocol) server for SkillKit persistent memory",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/memory",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "CozoDB-backed semantic memory with embeddings for SkillKit",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/mesh",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Peer mesh network for multi-machine agent distribution",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/messaging",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Inter-agent messaging system for SkillKit",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/resources",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Bundled resources for SkillKit - agents, commands, profiles, guidelines, and hooks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillkit/tui",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Unified Terminal UI for SkillKit - Built on OpenTUI",
   "type": "module",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,24 +198,12 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     optionalDependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.39.0
-        version: 0.39.0
-      '@google/genai':
-        specifier: ^1.0.0
-        version: 1.40.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))
       better-sqlite3:
         specifier: ^12.0.0
         version: 12.6.2
       node-llama-cpp:
         specifier: ^3.15.0
         version: 3.15.1(typescript@5.9.3)
-      ollama:
-        specifier: ^0.5.0
-        version: 0.5.18
-      openai:
-        specifier: ^4.0.0
-        version: 4.104.0(ws@8.19.0)(zod@3.25.76)
       sqlite-vec:
         specifier: ^0.1.6
         version: 0.1.6
@@ -443,9 +431,6 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-
-  '@anthropic-ai/sdk@0.39.0':
-    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -883,15 +868,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@google/genai@1.40.0':
-    resolution: {integrity: sha512-fhIww8smT0QYRX78qWOiz/nIQhHMF5wXOrlXvj33HBrz3vKDBb+wibLcEmTA+L9dmPD4KmfNr7UF3LDQVTXNjA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
@@ -913,10 +889,6 @@ packages:
   '@isaacs/brace-expansion@5.0.0':
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
-
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -1317,10 +1289,6 @@ packages:
     peerDependencies:
       solid-js: 1.9.9
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1572,20 +1540,11 @@ packages:
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
-
-  '@types/node@24.10.13':
-    resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1672,14 +1631,6 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
-
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1842,9 +1793,6 @@ packages:
     resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -1871,9 +1819,6 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -2093,10 +2038,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2160,12 +2101,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2177,9 +2112,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2292,9 +2224,6 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
-  extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
@@ -2315,10 +2244,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
 
   file-type@16.5.4:
     resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
@@ -2365,13 +2290,6 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
@@ -2379,14 +2297,6 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2428,14 +2338,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
-  gaxios@7.1.3:
-    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
-    engines: {node: '>=18'}
-
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
-    engines: {node: '>=18'}
-
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2473,11 +2375,6 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -2485,14 +2382,6 @@ packages:
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  google-auth-library@10.5.0:
-    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
-    engines: {node: '>=18'}
-
-  google-logging-utils@1.1.3:
-    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
-    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2504,10 +2393,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  gtoken@8.0.0:
-    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
-    engines: {node: '>=18'}
 
   guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
@@ -2552,16 +2437,9 @@ packages:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
 
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
-
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2661,9 +2539,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
   jimp@1.6.0:
     resolution: {integrity: sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==}
     engines: {node: '>=18'}
@@ -2696,9 +2571,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-bigint@1.0.0:
-    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
-
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -2712,12 +2584,6 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jwa@2.0.1:
-    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-
-  jws@4.0.1:
-    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -2830,9 +2696,6 @@ packages:
 
   long@4.0.0:
     resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
-
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -3010,11 +2873,6 @@ packages:
   node-api-headers@1.8.0:
     resolution: {integrity: sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3023,10 +2881,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-llama-cpp@3.15.1:
     resolution: {integrity: sha512-/fBNkuLGR2Q8xj2eeV12KXKZ9vCS2+o6aP11lW40pB9H6f0B3wOALi/liFrjhHukAoiH6C9wFTPzv6039+5DRA==}
@@ -3075,9 +2929,6 @@ packages:
     resolution: {integrity: sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==}
     engines: {node: '>= 20'}
 
-  ollama@0.5.18:
-    resolution: {integrity: sha512-lTFqTf9bo7Cd3hpF6CviBe/DEhewjoZYd9N/uCe7O20qYTvGqrNOFOBDj3lbZgFWHUgDv5EeyusYxsZSLS8nvg==}
-
   omggif@1.0.10:
     resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
 
@@ -3109,18 +2960,6 @@ packages:
   onnxruntime-web@1.14.0:
     resolution: {integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==}
 
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
@@ -3144,9 +2983,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
@@ -3323,10 +3159,6 @@ packages:
     resolution: {integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==}
     hasBin: true
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
-    engines: {node: '>=12.0.0'}
-
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -3418,10 +3250,6 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
   rollup@4.56.0:
@@ -3618,10 +3446,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -3838,14 +3662,8 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   universal-github-app-jwt@2.2.2:
     resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
@@ -3975,14 +3793,6 @@ packages:
       jsdom:
         optional: true
 
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
-
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-
   web-tree-sitter@0.25.10:
     resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
     peerDependencies:
@@ -3993,9 +3803,6 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4025,10 +3832,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -4104,19 +3907,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-
-  '@anthropic-ai/sdk@0.39.0':
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    optional: true
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -4469,19 +4259,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@google/genai@1.40.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))':
-    dependencies:
-      google-auth-library: 10.5.0
-      protobufjs: 7.5.4
-      ws: 8.19.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.7)(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   '@hono/node-server@1.19.9(hono@4.11.7)':
     dependencies:
       hono: 4.11.7
@@ -4496,16 +4273,6 @@ snapshots:
   '@isaacs/brace-expansion@5.0.0':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
-
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.2
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-    optional: true
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -5044,9 +4811,6 @@ snapshots:
       - typescript
       - web-tree-sitter
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
-
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -5218,27 +4982,11 @@ snapshots:
 
   '@types/long@4.0.2': {}
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 22.19.7
-      form-data: 4.0.5
-    optional: true
-
   '@types/node@16.9.1': {}
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-    optional: true
 
   '@types/node@22.19.7':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/node@24.10.13':
-    dependencies:
-      undici-types: 7.16.0
-    optional: true
 
   '@types/prop-types@15.7.15': {}
 
@@ -5359,14 +5107,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  agent-base@7.1.4:
-    optional: true
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-    optional: true
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
@@ -5520,9 +5260,6 @@ snapshots:
       prebuild-install: 7.1.3
     optional: true
 
-  bignumber.js@9.3.1:
-    optional: true
-
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -5569,9 +5306,6 @@ snapshots:
       electron-to-chromium: 1.5.283
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  buffer-equal-constant-time@1.0.1:
-    optional: true
 
   buffer@5.7.1:
     dependencies:
@@ -5796,9 +5530,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-uri-to-buffer@4.0.1:
-    optional: true
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -5846,14 +5577,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0:
-    optional: true
-
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
-
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.283: {}
@@ -5861,9 +5584,6 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2:
-    optional: true
 
   encodeurl@2.0.0: {}
 
@@ -6043,9 +5763,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extend@3.0.2:
-    optional: true
-
   fast-content-type-parse@3.0.0:
     optional: true
 
@@ -6058,12 +5775,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
-
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-    optional: true
 
   file-type@16.5.4:
     dependencies:
@@ -6118,15 +5829,6 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-    optional: true
-
-  form-data-encoder@1.7.2:
-    optional: true
-
   form-data-encoder@4.1.0: {}
 
   form-data@4.0.5:
@@ -6136,17 +5838,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-    optional: true
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
-    optional: true
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
     optional: true
 
   forwarded@0.2.0: {}
@@ -6197,25 +5888,6 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
-  gaxios@7.1.3:
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6
-      node-fetch: 3.3.2
-      rimraf: 5.0.10
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  gcp-metadata@8.1.2:
-    dependencies:
-      gaxios: 7.1.3
-      google-logging-utils: 1.1.3
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5:
@@ -6257,16 +5929,6 @@ snapshots:
 
   github-from-package@0.0.0: {}
 
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-    optional: true
-
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -6282,22 +5944,6 @@ snapshots:
       minimatch: 8.0.4
       minipass: 4.2.8
       path-scurry: 1.11.1
-
-  google-auth-library@10.5.0:
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.3
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
-      gtoken: 8.0.0
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  google-logging-utils@1.1.3:
-    optional: true
 
   gopd@1.2.0: {}
 
@@ -6317,14 +5963,6 @@ snapshots:
       type-fest: 4.41.0
 
   graceful-fs@4.2.11:
-    optional: true
-
-  gtoken@8.0.0:
-    dependencies:
-      gaxios: 7.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   guid-typescript@1.0.9: {}
@@ -6371,20 +6009,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   human-signals@5.0.0: {}
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-    optional: true
 
   iconv-lite@0.7.2:
     dependencies:
@@ -6489,13 +6114,6 @@ snapshots:
       sha.js: 2.4.12
       simple-get: 4.0.1
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-    optional: true
-
   jimp@1.6.0:
     dependencies:
       '@jimp/core': 1.6.0
@@ -6543,11 +6161,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-bigint@1.0.0:
-    dependencies:
-      bignumber.js: 9.3.1
-    optional: true
-
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -6559,19 +6172,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    optional: true
-
-  jwa@2.0.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-    optional: true
-
-  jws@4.0.1:
-    dependencies:
-      jwa: 2.0.1
-      safe-buffer: 5.2.1
     optional: true
 
   keyv@5.6.0:
@@ -6665,9 +6265,6 @@ snapshots:
     optional: true
 
   long@4.0.0: {}
-
-  long@5.3.2:
-    optional: true
 
   loupe@2.3.7:
     dependencies:
@@ -6812,19 +6409,9 @@ snapshots:
   node-api-headers@1.8.0:
     optional: true
 
-  node-domexception@1.0.0:
-    optional: true
-
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-    optional: true
 
   node-llama-cpp@3.15.1(typescript@5.9.3):
     dependencies:
@@ -6922,11 +6509,6 @@ snapshots:
       '@octokit/webhooks': 14.2.0
     optional: true
 
-  ollama@0.5.18:
-    dependencies:
-      whatwg-fetch: 3.6.20
-    optional: true
-
   omggif@1.0.10: {}
 
   on-finished@2.4.1:
@@ -6965,22 +6547,6 @@ snapshots:
       onnxruntime-common: 1.14.0
       platform: 1.3.6
 
-  openai@4.104.0(ws@8.19.0)(zod@3.25.76):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 8.19.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-    optional: true
-
   ora@8.2.0:
     dependencies:
       chalk: 5.6.2
@@ -7008,9 +6574,6 @@ snapshots:
       p-limit: 2.3.0
 
   p-try@2.2.0: {}
-
-  package-json-from-dist@1.0.1:
-    optional: true
 
   pako@1.0.11: {}
 
@@ -7172,22 +6735,6 @@ snapshots:
       '@types/node': 22.19.7
       long: 4.0.0
 
-  protobufjs@7.5.4:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.10.13
-      long: 5.3.2
-    optional: true
-
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -7280,11 +6827,6 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
-
-  rimraf@5.0.10:
-    dependencies:
-      glob: 10.5.0
-    optional: true
 
   rollup@4.56.0:
     dependencies:
@@ -7545,13 +7087,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
-    optional: true
-
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -7785,13 +7320,7 @@ snapshots:
 
   ufo@1.6.3: {}
 
-  undici-types@5.26.5:
-    optional: true
-
   undici-types@6.21.0: {}
-
-  undici-types@7.16.0:
-    optional: true
 
   universal-github-app-jwt@2.2.2:
     optional: true
@@ -7939,18 +7468,9 @@ snapshots:
       - supports-color
       - terser
 
-  web-streams-polyfill@3.3.3:
-    optional: true
-
-  web-streams-polyfill@4.0.0-beta.3:
-    optional: true
-
   web-tree-sitter@0.25.10: {}
 
   webidl-conversions@3.0.1: {}
-
-  whatwg-fetch@3.6.20:
-    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -7990,13 +7510,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    optional: true
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.1.2
     optional: true
 
   wrappy@1.0.2: {}

--- a/scripts/gen-tags.mjs
+++ b/scripts/gen-tags.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = resolve(root, 'assets/tags');
+mkdirSync(outDir, { recursive: true });
+
+const FONT = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+const PAD_X = 14;
+const H = 28;
+const R = 4;
+
+const CHAR_W = 7.2;
+const BADGE_CHAR_W = 7.0;
+
+function pill({ text, fg = '#fafafa', bg = '#09090b', stroke = '#3f3f46', accent }) {
+  const w = Math.round(text.length * CHAR_W + PAD_X * 2);
+  const accentBar = accent
+    ? `<rect x="0" y="0" width="4" height="${H}" fill="${accent}"/>`
+    : '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${H}" viewBox="0 0 ${w} ${H}" role="img">
+  <rect x="0.5" y="0.5" width="${w - 1}" height="${H - 1}" rx="${R}" ry="${R}" fill="${bg}" stroke="${stroke}"/>
+  ${accentBar}
+  <text x="${accent ? PAD_X + 4 : w / 2}" y="18" text-anchor="${accent ? 'start' : 'middle'}" font-family="${FONT}" font-size="12" font-weight="600" fill="${fg}" letter-spacing="0.3">${text}</text>
+</svg>`;
+}
+
+function splitPill({ label, value, labelBg = '#18181b', valueBg = '#09090b', labelFg = '#a1a1aa', valueFg = '#fafafa', stroke = '#3f3f46' }) {
+  const lw = Math.round(label.length * BADGE_CHAR_W + PAD_X);
+  const vw = Math.round(value.length * BADGE_CHAR_W + PAD_X);
+  const w = lw + vw;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${H}" viewBox="0 0 ${w} ${H}" role="img">
+  <clipPath id="c"><rect width="${w}" height="${H}" rx="${R}" ry="${R}"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="${lw}" height="${H}" fill="${labelBg}"/>
+    <rect x="${lw}" width="${vw}" height="${H}" fill="${valueBg}"/>
+    <rect x="0.5" y="0.5" width="${w - 1}" height="${H - 1}" fill="none" stroke="${stroke}" rx="${R}" ry="${R}"/>
+    <text x="${lw / 2}" y="18" text-anchor="middle" font-family="${FONT}" font-size="12" font-weight="500" fill="${labelFg}" letter-spacing="0.3">${label}</text>
+    <text x="${lw + vw / 2}" y="18" text-anchor="middle" font-family="${FONT}" font-size="12" font-weight="700" fill="${valueFg}" letter-spacing="0.3">${value}</text>
+  </g>
+</svg>`;
+}
+
+const tags = [
+  { name: 'slim-install.svg', svg: pill({ text: 'slim install', accent: '#3b82f6' }) },
+  { name: 'new.svg',          svg: pill({ text: 'new',          accent: '#22c55e' }) },
+  { name: 'v1.23.0.svg',      svg: pill({ text: 'v1.23.0',      accent: '#3b82f6' }) },
+  { name: 'official.svg',     svg: pill({ text: 'official',     accent: '#f59e0b' }) },
+  { name: 'community.svg',    svg: pill({ text: 'community',    accent: '#a78bfa' }) },
+  { name: 'curated.svg',      svg: pill({ text: 'curated',      accent: '#06b6d4' }) },
+  { name: 'open-source.svg',  svg: pill({ text: 'open source',  accent: '#f472b6' }) },
+  { name: 'prs-welcome.svg',  svg: pill({ text: 'PRs welcome',  accent: '#22c55e' }) },
+  { name: 'one-skill.svg',    svg: pill({ text: 'one skill',    accent: '#3b82f6' }) },
+  { name: 'every-agent.svg',  svg: pill({ text: 'every agent',  accent: '#3b82f6' }) },
+
+  { name: 'agents.svg',       svg: splitPill({ label: 'agents',   value: '45'     }) },
+  { name: 'skills.svg',       svg: splitPill({ label: 'skills',   value: '400K+'  }) },
+  { name: 'sources.svg',      svg: splitPill({ label: 'sources',  value: '31'     }) },
+  { name: 'tests.svg',        svg: splitPill({ label: 'tests',    value: '757'    }) },
+  { name: 'install.svg',      svg: splitPill({ label: 'install',  value: '9s',    valueBg: '#22c55e', valueFg: '#000' }) },
+  { name: 'packages.svg',     svg: splitPill({ label: 'packages', value: '118',   valueBg: '#3b82f6', valueFg: '#fff' }) },
+  { name: 'deprecations.svg', svg: splitPill({ label: 'deprecations', value: '0', valueBg: '#22c55e', valueFg: '#000' }) },
+  { name: 'vulns.svg',        svg: splitPill({ label: 'vulns',    value: '0',     valueBg: '#22c55e', valueFg: '#000' }) },
+  { name: 'license.svg',      svg: splitPill({ label: 'license',  value: 'Apache-2.0' }) },
+  { name: 'node.svg',         svg: splitPill({ label: 'node',     value: '>=18' }) },
+];
+
+for (const { name, svg } of tags) {
+  writeFileSync(resolve(outDir, name), svg);
+  console.log(`wrote assets/tags/${name}`);
+}


### PR DESCRIPTION
## Summary

- Version: **1.22.1 → 1.23.0** across all workspace packages.
- Pruned 4 dead optional deps in \`@skillkit/core\`
  (\`@anthropic-ai/sdk\`, \`@google/genai\`, \`ollama\`, \`openai\`).
  Listed as optional but never imported — providers use \`fetch()\` directly.
  Drops ~57 packages and 1 deprecation warning from the default install.
- Rewrote README with punchier fold, collapsible feature blocks,
  brand-aligned SVG tags under \`assets/tags/\`, no em dashes.
- Added \`scripts/gen-tags.mjs\` generator for the 20 SVG tag badges
  in SkillKit's monochrome palette (#09090b base, #fafafa text,
  #3f3f46 border, per-tag accent stripe).

## Install numbers (measured on fresh npm cache)

| Mode                                | Packages | Time | Deprecations | Vulns (crit/high) |
| :---------------------------------- | -------: | :--: | -----------: | ----------------: |
| v1.22.1 (baseline)                  |      544 | 37 s |           10 |     5/5 (critical)|
| v1.23.0 default                     |      418 | 18 s |            2 |               0/0 |
| v1.23.0 \`--omit=optional\`           |      118 |  9 s |            0 |               0/0 |

Remaining 2 warnings in the default install are upstream:
- \`prebuild-install@7.1.3\` from \`better-sqlite3\` (actively used)
- \`glob@9.3.5\` from \`@opentui/solid → babel-plugin-module-resolver\`
Not ours to fix.

## Test plan

- [x] \`pnpm build\` green (all 13 tasks).
- [x] CLI tests: 41/41 pass. App tests: 3/3 pass.
- [x] \`npm pack\` every workspace pkg, install with \`overrides\`
      in a clean cache (full + slim). Both run \`skillkit --help\`,
      \`skillkit --version\`, \`skillkit list\`.
- [x] Confirmed the 2 remaining deprecation sources via \`npm ls\`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added badge generation for visual marketing assets.

* **Documentation**
  * Revamped README with improved marketing sections and quick-start guide.
  * Enhanced installation examples with clearer optional-package options.
  * Reorganized supported agents section for improved readability.
  * Updated command references and usage examples.

* **Chores**
  * Released version 1.23.0.
  * Streamlined optional dependencies in core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->