### PR TITLE
fix(openclaw): align paths with upstream openclaw/openclaw conventions

### DIFF
--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -23,7 +23,7 @@ npm install @skillkit/agents
 | Antigravity | SKILL.md | `.antigravity/skills/` | - |
 | Amp | SKILL.md | `.amp/skills/` | - |
 | Clawdbot | SKILL.md | `.clawdbot/skills/` | - |
-| OpenClaw | SKILL.md | `skills/` | - |
+| OpenClaw | SKILL.md | `.openclaw/skills/` | `~/.openclaw/workspace/skills/` |
 | Cline | SKILL.md | `.cline/skills/` | - |
 | CodeBuddy | SKILL.md | `.codebuddy/skills/` | - |
 | CodeGPT | SKILL.md | `.codegpt/skills/` | - |

--- a/packages/agents/src/openclaw.ts
+++ b/packages/agents/src/openclaw.ts
@@ -14,9 +14,12 @@ export class OpenClawAdapter extends ClawdbotAdapter {
   override readonly configFile = config.configFile;
 
   override async isDetected(): Promise<boolean> {
+    const projectOpenClaw = join(process.cwd(), '.openclaw');
     const globalOpenClaw = join(homedir(), '.openclaw');
+    const globalWorkspace = join(homedir(), '.openclaw', 'workspace');
     const openclawConfig = join(process.cwd(), 'openclaw.json');
 
-    return existsSync(globalOpenClaw) || existsSync(openclawConfig);
+    return existsSync(projectOpenClaw) || existsSync(globalOpenClaw) ||
+           existsSync(globalWorkspace) || existsSync(openclawConfig);
   }
 }

--- a/packages/core/src/agent-config.ts
+++ b/packages/core/src/agent-config.ts
@@ -121,10 +121,10 @@ export const AGENT_CONFIG: Record<AgentType, AgentDirectoryConfig> = {
   },
 
   openclaw: {
-    skillsDir: 'skills',
-    configFile: 'CLAUDE.md',
-    altSkillsDirs: ['~/.openclaw/skills'],
-    globalSkillsDir: '~/.openclaw/skills',
+    skillsDir: '.openclaw/skills',
+    configFile: 'AGENTS.md',
+    altSkillsDirs: ['skills', '~/.openclaw/workspace/skills'],
+    globalSkillsDir: '~/.openclaw/workspace/skills',
     configFormat: 'xml',
     usesFrontmatter: true,
     frontmatterFields: [

--- a/packages/core/src/agent-config.ts
+++ b/packages/core/src/agent-config.ts
@@ -15,6 +15,8 @@ export interface AgentDirectoryConfig {
   skillsDir: string;
   /** Config file that references skills */
   configFile: string;
+  /** Alternative config files that also mark this agent as present */
+  altConfigFiles?: string[];
   /** Alternative skills directories */
   altSkillsDirs?: string[];
   /** Global skills directory */
@@ -123,6 +125,7 @@ export const AGENT_CONFIG: Record<AgentType, AgentDirectoryConfig> = {
   openclaw: {
     skillsDir: '.openclaw/skills',
     configFile: 'AGENTS.md',
+    altConfigFiles: ['openclaw.json'],
     altSkillsDirs: ['skills', '~/.openclaw/workspace/skills'],
     globalSkillsDir: '~/.openclaw/workspace/skills',
     configFormat: 'xml',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { SkillkitConfig, LockFile, type AgentType, type SkillMetadata, type AgentAdapterInfo, type LockEntry } from './types.js';
+import { AGENT_CONFIG } from './agent-config.js';
 
 const CONFIG_FILE = 'skillkit.yaml';
 const METADATA_FILE = '.skillkit.json';
@@ -99,7 +100,16 @@ export function getSearchDirs(adapter: AgentAdapterInfo): string[] {
 
   dirs.push(join(process.cwd(), adapter.skillsDir));
   dirs.push(join(process.cwd(), '.agent', 'skills'));
-  dirs.push(join(homedir(), adapter.skillsDir));
+
+  const globalDir = AGENT_CONFIG[adapter.type]?.globalSkillsDir;
+  if (globalDir) {
+    const resolved = globalDir.startsWith('~/')
+      ? join(homedir(), globalDir.slice(2))
+      : globalDir;
+    dirs.push(resolved);
+  } else {
+    dirs.push(join(homedir(), adapter.skillsDir));
+  }
   dirs.push(join(homedir(), '.agent', 'skills'));
 
   return dirs;

--- a/packages/core/src/context/sync.ts
+++ b/packages/core/src/context/sync.ts
@@ -55,8 +55,11 @@ export class ContextSync {
       const skillsPath = join(this.projectPath, config.skillsDir);
       const configPath = join(this.projectPath, config.configFile);
 
-      // Check if either skills directory or config file exists
-      if (existsSync(skillsPath) || existsSync(configPath)) {
+      const altConfigExists = (config.altConfigFiles ?? []).some((alt) =>
+        existsSync(join(this.projectPath, alt))
+      );
+
+      if (existsSync(skillsPath) || existsSync(configPath) || altConfigExists) {
         detected.push(agent as AgentType);
       }
     }

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -41,6 +41,7 @@ export const SKILL_DISCOVERY_PATHS = [
   '.mux/skills',
   '.neovate/skills',
   '.opencode/skills',
+  '.openclaw/skills',
   '.openhands/skills',
   '.pi/skills',
   '.playcode/skills',

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -185,7 +185,7 @@ const AGENT_DIR_MAP: Record<string, string[]> = {
   'claude-code': ['.claude/skills'], 'cursor': ['.cursor/skills'], 'codex': ['.codex/skills'],
   'gemini-cli': ['.gemini/skills'], 'opencode': ['.opencode/skills', '.config/opencode/skills'],
   'antigravity': ['.antigravity/skills'], 'amp': ['.amp/skills'], 'clawdbot': ['.clawdbot/skills'],
-  'openclaw': ['skills'], 'github-copilot': ['.github/skills'], 'goose': ['.goose/skills'],
+  'openclaw': ['.openclaw/skills', 'skills'], 'github-copilot': ['.github/skills'], 'goose': ['.goose/skills'],
   'kilo': ['.kilocode/skills'], 'kiro-cli': ['.kiro/skills'], 'roo': ['.roo/skills'],
   'trae': ['.trae/skills'], 'windsurf': ['.windsurf/skills', '.codeium/windsurf/skills'],
   'universal': ['skills'], 'droid': ['.factory/skills'], 'factory': ['.factory/skills'],

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -185,7 +185,7 @@ const AGENT_DIR_MAP: Record<string, string[]> = {
   'claude-code': ['.claude/skills'], 'cursor': ['.cursor/skills'], 'codex': ['.codex/skills'],
   'gemini-cli': ['.gemini/skills'], 'opencode': ['.opencode/skills', '.config/opencode/skills'],
   'antigravity': ['.antigravity/skills'], 'amp': ['.amp/skills'], 'clawdbot': ['.clawdbot/skills'],
-  'openclaw': ['.openclaw/skills', 'skills'], 'github-copilot': ['.github/skills'], 'goose': ['.goose/skills'],
+  'openclaw': ['.openclaw/skills', '.openclaw/workspace/skills', 'skills'], 'github-copilot': ['.github/skills'], 'goose': ['.goose/skills'],
   'kilo': ['.kilocode/skills'], 'kiro-cli': ['.kiro/skills'], 'roo': ['.roo/skills'],
   'trae': ['.trae/skills'], 'windsurf': ['.windsurf/skills', '.codeium/windsurf/skills'],
   'universal': ['skills'], 'droid': ['.factory/skills'], 'factory': ['.factory/skills'],


### PR DESCRIPTION
## Summary

While reviewing #114 (Hermes support), noticed OpenClaw config drifts from real openclaw/openclaw upstream layout. This PR aligns it.

## Upstream (openclaw/openclaw)

- Project skills: `.openclaw/skills/<name>/SKILL.md`
- Global skills: `~/.openclaw/workspace/skills/<name>/SKILL.md`
- Instructions: `AGENTS.md` (+ SOUL.md, TOOLS.md)
- Config: `openclaw.json`

## Current vs upstream

| Field | Main | Upstream | Fixed |
|---|---|---|---|
| skillsDir | `skills` | `.openclaw/skills` | yes |
| configFile | `CLAUDE.md` | `AGENTS.md` | yes |
| globalSkillsDir | `~/.openclaw/skills` | `~/.openclaw/workspace/skills` | yes |
| altSkillsDirs | `['~/.openclaw/skills']` | — | kept `skills` back-compat + added workspace |
| isDetected | `~/.openclaw` + `openclaw.json` | should also check project `.openclaw/` + workspace | yes |
| MCP AGENT_DIR_MAP | `['skills']` | `['.openclaw/skills']` | yes |

## Changes

- `packages/core/src/agent-config.ts`: skillsDir, configFile, globalSkillsDir, altSkillsDirs
- `packages/agents/src/openclaw.ts`: isDetected adds `.openclaw/` and `workspace/`
- `packages/mcp/src/tools.ts`: AGENT_DIR_MAP runtime discovery for `.openclaw/skills`
- `packages/agents/README.md`: table reflects real paths

## Validation

- @skillkit/core build ok
- @skillkit/agents build ok
- @skillkit/core typecheck ok
- @skillkit/agents typecheck ok
- @skillkit/agents test 189/189 pass

## Back-compat

`altSkillsDirs: ['skills', '~/.openclaw/workspace/skills']` keeps old bare `skills/` dir detectable so projects installed before this fix keep working.

## Follow-up

After #114 lands, Hermes has 17 touchpoints. OpenClaw now has matching path coverage. Both match upstream conventions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenClaw docs to reflect new skill paths and config filename.

* **Chores**
  * Project-local skills moved to .openclaw/skills/.
  * Added workspace-level skills at ~/.openclaw/workspace/skills/.
  * Configuration filename changed to AGENTS.md.

* **Bug Fixes / Improvements**
  * Improved OpenClaw detection to recognize the new local and workspace locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->