### PR TITLE
chore: edge cache headers + agent-aware robots + bot-block middleware

### DIFF
--- a/docs/fumadocs/next.config.mjs
+++ b/docs/fumadocs/next.config.mjs
@@ -8,6 +8,34 @@ const config = {
   trailingSlash: false,
   skipTrailingSlashRedirect: true,
   assetPrefix: 'https://skillkit-docs.vercel.app',
+  async headers() {
+    return [
+      {
+        source: '/:path*.(css|js|png|jpg|jpeg|svg|webp|woff2|woff|ttf|ico)',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000' },
+        ],
+      },
+      {
+        source: '/_next/static/:path*',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+        ],
+      },
+      {
+        source: '/docs/:path*',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=300, s-maxage=86400, stale-while-revalidate=604800' },
+        ],
+      },
+      {
+        source: '/',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=300, s-maxage=86400, stale-while-revalidate=604800' },
+        ],
+      },
+    ];
+  },
 };
 
 export default withMDX(config);

--- a/docs/fumadocs/public/robots.txt
+++ b/docs/fumadocs/public/robots.txt
@@ -1,0 +1,138 @@
+# Humans + agents welcome. Training crawlers + SEO scrapers blocked.
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: FirecrawlAgent
+Allow: /
+
+User-agent: firecrawl
+Allow: /
+
+User-agent: Context7Bot
+Allow: /
+
+User-agent: Crawl4AI
+Allow: /
+
+User-agent: Clawdbot
+Allow: /
+
+User-agent: OpenClaw
+Allow: /
+
+User-agent: Hermes
+Allow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: peer39_crawler
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: ICC-Crawler
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: MegaIndex
+Disallow: /
+
+User-agent: SeznamBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: https://skillkit-docs.vercel.app/sitemap.xml

--- a/docs/fumadocs/src/middleware.ts
+++ b/docs/fumadocs/src/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const BLOCK = /GPTBot|ClaudeBot|anthropic-ai|CCBot|Google-Extended|Applebot-Extended|Bytespider|Amazonbot|Meta-ExternalAgent|cohere-ai|Diffbot|ImagesiftBot|Omgilibot|peer39_crawler|YouBot|Timpibot|ICC-Crawler|AhrefsBot|SemrushBot|MJ12bot|DotBot|PetalBot|BLEXBot|MegaIndex|SeznamBot|DataForSeoBot/i;
+
+const ALLOW = /Googlebot|Bingbot|DuckDuckBot|Applebot(?!-Extended)|ChatGPT-User|OAI-SearchBot|PerplexityBot|Perplexity-User|Claude-User|Claude-SearchBot|FirecrawlAgent|firecrawl|Context7Bot|Crawl4AI|Clawdbot|OpenClaw|Hermes/i;
+
+export function middleware(req: NextRequest) {
+  const ua = req.headers.get('user-agent') || '';
+  if (ALLOW.test(ua)) return NextResponse.next();
+  if (BLOCK.test(ua)) {
+    return new NextResponse('disallowed by robots.txt', {
+      status: 403,
+      headers: { 'Cache-Control': 'public, max-age=86400' },
+    });
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/((?!_next/static|_next/image|favicon|robots\\.txt|sitemap\\.xml).*)',
+};

--- a/docs/skillkit/public/robots.txt
+++ b/docs/skillkit/public/robots.txt
@@ -1,0 +1,138 @@
+# Humans + agents welcome. Training crawlers + SEO scrapers blocked.
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: FirecrawlAgent
+Allow: /
+
+User-agent: firecrawl
+Allow: /
+
+User-agent: Context7Bot
+Allow: /
+
+User-agent: Crawl4AI
+Allow: /
+
+User-agent: Clawdbot
+Allow: /
+
+User-agent: OpenClaw
+Allow: /
+
+User-agent: Hermes
+Allow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: peer39_crawler
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: ICC-Crawler
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: MegaIndex
+Disallow: /
+
+User-agent: SeznamBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: https://skillkit.dev/sitemap.xml

--- a/docs/skillkit/vercel.json
+++ b/docs/skillkit/vercel.json
@@ -21,5 +21,47 @@
       "source": "/docs",
       "destination": "https://skillkit-docs.vercel.app/docs"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)\\.(css|js|png|jpg|jpeg|svg|webp|woff2|woff|ttf|ico|mp4)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
+    },
+    {
+      "source": "/api",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800" }
+      ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/((?!robots\\.txt$).*)",
+      "has": [
+        { "type": "header", "key": "user-agent", "value": "(?i).*(GPTBot|ClaudeBot|anthropic-ai|CCBot|Google-Extended|Applebot-Extended|Bytespider|Amazonbot|Meta-ExternalAgent|cohere-ai|Diffbot|ImagesiftBot|Omgilibot|peer39_crawler|YouBot|Timpibot|ICC-Crawler|AhrefsBot|SemrushBot|MJ12bot|DotBot|PetalBot|BLEXBot|MegaIndex|SeznamBot|DataForSeoBot).*" }
+      ],
+      "destination": "/robots.txt",
+      "permanent": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
Two Vercel projects covered: **skillkit** (Vite marketing site, `docs/skillkit/`) and **skillkit-docs** (Next.js fumadocs, `docs/fumadocs/`).

### skillkit (Vite, `docs/skillkit/`)
- `vercel.json` `headers`: `Cache-Control` on assets (1d browser, 7d edge, 30d SWR), `/assets/*` immutable for 1y (Vite hashes filenames), HTML (5min/1d/7d), `/api` JSON (5min/1d/7d)
- `vercel.json` `redirects`: deflect known training+SEO bots to `/robots.txt` via `has` user-agent matcher; source uses negative lookahead so `/robots.txt` itself never matches (no redirect loop)
- `public/robots.txt`: explicit allow + deny lists

### skillkit-docs (Next.js fumadocs, `docs/fumadocs/`)
- `next.config.mjs` `headers()`: `/_next/static/*` immutable for 1y, assets 1d/7d/30d, `/docs/*` and `/` 5min/1d/7d
- `src/middleware.ts`: UA allow-list passes through, deny-list returns 403 with `Cache-Control: max-age=86400` so the rejection itself is edge-cached
- `public/robots.txt`: same agent-aware allow + deny lists

## Why
Vercel hobby plan hit edge-request and Web Analytics caps. Per Vercel usage chart for Apr:
- skillkit: 181K edge req
- skillkit-docs: 85K edge req

`docs/skillkit/vercel.json` rewrites `/_next/*` and `/docs/*` to `https://skillkit-docs.vercel.app/...`, so every docs pageview fires on **both** projects. Compounding both with cache headers + bot deflection is needed.

## Bot policy (both projects)
**Allowed:** Googlebot, Bingbot, DuckDuckBot, Applebot, ChatGPT-User, OAI-SearchBot, PerplexityBot, Perplexity-User, Claude-User, Claude-SearchBot, FirecrawlAgent, Context7Bot, Crawl4AI, Clawdbot, OpenClaw, Hermes — plus default `User-agent: *` allow.

**Disallowed:** GPTBot, ClaudeBot, anthropic-ai, CCBot, Google-Extended, Applebot-Extended, Bytespider, Amazonbot, Meta-ExternalAgent, cohere-ai, Diffbot, ImagesiftBot, Omgilibot, peer39_crawler, YouBot, Timpibot, ICC-Crawler, AhrefsBot, SemrushBot, MJ12bot, DotBot, PetalBot, BLEXBot, MegaIndex, SeznamBot, DataForSeoBot.

## Test plan
- [ ] Both Vercel preview builds succeed
- [ ] `https://<preview-skillkit>.vercel.app/robots.txt` returns expected content
- [ ] `https://<preview-skillkit-docs>.vercel.app/robots.txt` returns expected content
- [ ] Asset response includes `Cache-Control: public, max-age=86400, ...`
- [ ] `/_next/static/*` includes `Cache-Control: public, max-age=31536000, immutable`
- [ ] `curl -A 'SemrushBot/7.0' https://<preview-skillkit>` returns 307 to `/robots.txt`
- [ ] `curl -A 'SemrushBot/7.0' https://<preview-skillkit>/robots.txt` returns 200 (no loop)
- [ ] `curl -A 'SemrushBot/7.0' https://<preview-docs>/docs/...` returns 403
- [ ] `curl -A 'ChatGPT-User' https://<preview-docs>/docs/...` returns 200
- [ ] `curl -A 'FirecrawlAgent/1.0' https://<preview-docs>/docs/...` returns 200
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced site performance through optimized caching configurations for static assets and routes, including long-lived immutable caching for frequently accessed resources
  * Improved search engine optimization with crawler access rules and sitemap directives
  * Implemented request filtering and management for bot access across the platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->