### PR TITLE
feat: add dotnet recommendation support

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,6 +48,7 @@ skillkit read <skills>        # Read skill content
 
 ```bash
 skillkit recommend                     # Project-based recommendations
+skillkit recommend --update            # Refresh index from built-ins and taps
 skillkit recommend --search "auth"     # Task-based search
 skillkit recommend --category security # Filter by category
 skillkit recommend --min-score 80      # Quality threshold
@@ -57,6 +58,24 @@ skillkit marketplace search "react"    # Search marketplace
 skillkit marketplace --tags typescript # Filter by tags
 skillkit marketplace refresh           # Refresh index
 ```
+
+`skillkit recommend --update` fetches skills from built-in recommendation sources
+and from custom GitHub taps added with `skillkit tap add <owner>/<repo>`. Sources
+are deduplicated by `owner/repo`; invalid tap entries are reported as warnings
+and skipped without failing the update.
+
+Recommendations use the project context detected for the current path. .NET
+projects are detected from standard markers including `*.sln`, `*.slnx`,
+`*.csproj`, `*.fsproj`, `*.vbproj`, `global.json`,
+`Directory.Build.props`, `Directory.Build.targets`,
+`Directory.Packages.props`, `NuGet.config`, and `packages.config`.
+The detector recognizes C#, F#, Visual Basic, the `dotnet` runtime, SDK versions
+from `global.json`, ASP.NET Core, Blazor, MAUI, xUnit, NUnit, MSTest, MSBuild,
+and NuGet markers.
+
+If an existing project already has a stale `.skillkit/context.yaml`, refresh the
+context with `skillkit context init` or reinitialize SkillKit so recommendations
+can use newly detected stack data.
 
 ### Translation
 

--- a/packages/cli/src/__tests__/recommend-sources.test.ts
+++ b/packages/cli/src/__tests__/recommend-sources.test.ts
@@ -37,6 +37,7 @@ describe('recommend source resolution', () => {
     const taps: TapEntry[] = [
       { source: `${builtIn.owner}/${builtIn.repo}`, addedAt: '2026-06-14T00:00:00.000Z' },
       { source: 'some-org/some-skills', addedAt: '2026-06-14T00:00:00.000Z' },
+      { source: 'Some-Org/Some-Skills', addedAt: '2026-06-14T00:00:00.000Z' },
       { source: 'some-org/some-skills', addedAt: '2026-06-14T00:00:00.000Z' },
     ];
 
@@ -44,7 +45,7 @@ describe('recommend source resolution', () => {
     const names = result.sources.map((source) => `${source.owner}/${source.repo}`);
 
     expect(names.filter((name) => name === `${builtIn.owner}/${builtIn.repo}`)).toHaveLength(1);
-    expect(names.filter((name) => name === 'some-org/some-skills')).toHaveLength(1);
+    expect(names.filter((name) => name.toLowerCase() === 'some-org/some-skills')).toHaveLength(1);
   });
 
   it('should warn and skip invalid tap sources', () => {

--- a/packages/cli/src/__tests__/recommend-sources.test.ts
+++ b/packages/cli/src/__tests__/recommend-sources.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { buildRecommendationSources } from '../recommend-sources.js';
+import type { TapEntry } from '../helpers.js';
+
+const knownSkillRepos = [
+  {
+    owner: 'anthropics',
+    repo: 'courses',
+    description: 'Anthropic official courses and skills',
+  },
+  {
+    owner: 'vercel-labs',
+    repo: 'ai-sdk-preview-internal-knowledge-base',
+    description: 'Vercel AI SDK skills',
+  },
+];
+
+describe('recommend source resolution', () => {
+  it('should include built-in sources and valid custom taps', () => {
+    const taps: TapEntry[] = [
+      { source: 'some-org/some-skills', addedAt: '2026-06-14T00:00:00.000Z' },
+    ];
+
+    const result = buildRecommendationSources(knownSkillRepos, taps);
+
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(knownSkillRepos[0]),
+        expect.objectContaining({ owner: 'some-org', repo: 'some-skills' }),
+      ])
+    );
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('should dedupe duplicate owner/repo sources', () => {
+    const builtIn = knownSkillRepos[0];
+    const taps: TapEntry[] = [
+      { source: `${builtIn.owner}/${builtIn.repo}`, addedAt: '2026-06-14T00:00:00.000Z' },
+      { source: 'some-org/some-skills', addedAt: '2026-06-14T00:00:00.000Z' },
+      { source: 'some-org/some-skills', addedAt: '2026-06-14T00:00:00.000Z' },
+    ];
+
+    const result = buildRecommendationSources(knownSkillRepos, taps);
+    const names = result.sources.map((source) => `${source.owner}/${source.repo}`);
+
+    expect(names.filter((name) => name === `${builtIn.owner}/${builtIn.repo}`)).toHaveLength(1);
+    expect(names.filter((name) => name === 'some-org/some-skills')).toHaveLength(1);
+  });
+
+  it('should warn and skip invalid tap sources', () => {
+    const result = buildRecommendationSources(knownSkillRepos, [
+      { source: 'not-a-github-source', addedAt: '2026-06-14T00:00:00.000Z' },
+      { source: 'valid-org/valid-skills', addedAt: '2026-06-14T00:00:00.000Z' },
+    ]);
+
+    expect(result.sources).toContainEqual(
+      expect.objectContaining({ owner: 'valid-org', repo: 'valid-skills' })
+    );
+    expect(result.sources).not.toContainEqual(
+      expect.objectContaining({ owner: 'not-a-github-source' })
+    );
+    expect(result.warnings).toContain('Invalid tap source skipped: not-a-github-source');
+  });
+});

--- a/packages/cli/src/commands/recommend.ts
+++ b/packages/cli/src/commands/recommend.ts
@@ -14,6 +14,7 @@ import {
   INDEX_PATH,
   KNOWN_SKILL_REPOS,
 } from '@skillkit/core';
+import { loadTaps } from '../helpers.js';
 import {
   header,
   colors,
@@ -25,6 +26,7 @@ import {
   formatQualityBadge,
   getQualityGradeFromScore,
 } from '../onboarding/index.js';
+import { buildRecommendationSources } from '../recommend-sources.js';
 
 export class RecommendCommand extends Command {
   static override paths = [['recommend'], ['rec']];
@@ -687,23 +689,25 @@ export class RecommendCommand extends Command {
       header('Update Skill Index');
     }
 
-    console.log(colors.muted(`Sources: ${KNOWN_SKILL_REPOS.map(r => `${r.owner}/${r.repo}`).join(', ')}\n`));
+    const sourceResult = buildRecommendationSources(KNOWN_SKILL_REPOS, loadTaps().taps);
+    console.log(colors.muted(`Sources: ${sourceResult.sources.map(r => `${r.owner}/${r.repo}`).join(', ')}\n`));
 
     const s = spinner();
     s.start('Fetching skills...');
 
     try {
-      const { index, errors } = await buildSkillIndex(KNOWN_SKILL_REPOS, (message) => {
+      const { index, errors } = await buildSkillIndex(sourceResult.sources, (message) => {
         s.message(message);
       });
+      const allWarnings = [...sourceResult.warnings, ...errors];
 
       s.stop(`Fetched ${index.skills.length} skills`);
 
       // Report any errors
-      if (errors.length > 0) {
+      if (allWarnings.length > 0) {
         console.log('');
         console.log(colors.warning('Warnings:'));
-        for (const error of errors) {
+        for (const error of allWarnings) {
           console.log(colors.muted(`  ${symbols.stepActive} ${error}`));
         }
       }

--- a/packages/cli/src/commands/recommend.ts
+++ b/packages/cli/src/commands/recommend.ts
@@ -690,7 +690,9 @@ export class RecommendCommand extends Command {
     }
 
     const sourceResult = buildRecommendationSources(KNOWN_SKILL_REPOS, loadTaps().taps);
-    console.log(colors.muted(`Sources: ${sourceResult.sources.map(r => `${r.owner}/${r.repo}`).join(', ')}\n`));
+    if (!this.quiet && !this.json) {
+      console.log(colors.muted(`Sources: ${sourceResult.sources.map(r => `${r.owner}/${r.repo}`).join(', ')}\n`));
+    }
 
     const s = spinner();
     s.start('Fetching skills...');

--- a/packages/cli/src/recommend-sources.ts
+++ b/packages/cli/src/recommend-sources.ts
@@ -1,12 +1,7 @@
 import type { TapEntry } from './helpers.js';
+import type { SkillRepoSource } from '@skillkit/core';
 
 const GITHUB_REPO_PATTERN = /^([\w.-]+)\/([\w.-]+)$/;
-
-export interface SkillRepoSource {
-  owner: string;
-  repo: string;
-  description?: string;
-}
 
 export interface RecommendationSourcesResult {
   sources: SkillRepoSource[];

--- a/packages/cli/src/recommend-sources.ts
+++ b/packages/cli/src/recommend-sources.ts
@@ -1,0 +1,50 @@
+import type { TapEntry } from './helpers.js';
+
+const GITHUB_REPO_PATTERN = /^([\w.-]+)\/([\w.-]+)$/;
+
+export interface SkillRepoSource {
+  owner: string;
+  repo: string;
+  description?: string;
+}
+
+export interface RecommendationSourcesResult {
+  sources: SkillRepoSource[];
+  warnings: string[];
+}
+
+export function buildRecommendationSources(
+  builtInSources: readonly SkillRepoSource[],
+  taps: readonly TapEntry[],
+): RecommendationSourcesResult {
+  const sources: SkillRepoSource[] = [];
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+
+  function addSource(source: SkillRepoSource): void {
+    const key = `${source.owner.toLowerCase()}/${source.repo.toLowerCase()}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    sources.push(source);
+  }
+
+  for (const source of builtInSources) {
+    addSource(source);
+  }
+
+  for (const tap of taps) {
+    const match = GITHUB_REPO_PATTERN.exec(tap.source);
+    if (!match) {
+      warnings.push(`Invalid tap source skipped: ${tap.source}`);
+      continue;
+    }
+
+    addSource({
+      owner: match[1],
+      repo: match[2],
+      description: tap.name,
+    });
+  }
+
+  return { sources, warnings };
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,6 +83,16 @@ await ctx.init();
 const context = ctx.getContext();
 ```
 
+Project detection includes .NET repositories using common markers such as
+`*.sln`, `*.slnx`, project files (`*.csproj`, `*.fsproj`, `*.vbproj`),
+`global.json`, MSBuild props/targets, and NuGet config/package files. Detected
+.NET stack data includes language, `dotnet` runtime and SDK version, ASP.NET
+Core, Blazor, MAUI, xUnit, NUnit, MSTest, MSBuild, and NuGet signals.
+
+Existing projects with a stale `.skillkit/context.yaml` may need a context
+refresh or reinitialization before recommendations pick up newly supported
+markers.
+
 ### Session Memory
 
 ```typescript

--- a/packages/core/src/context/__tests__/detector.test.ts
+++ b/packages/core/src/context/__tests__/detector.test.ts
@@ -168,6 +168,100 @@ describe('ProjectDetector', () => {
         })
       );
     });
+
+    it('should detect .NET solution, project, SDK version, frameworks, testing, and tools', () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return false;
+        return [
+          'global.json',
+          'Directory.Build.props',
+          'Directory.Packages.props',
+          'MarketplaceDemo.slnx',
+          'Web.csproj',
+        ].some((file) => path.endsWith(file));
+      });
+
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return '';
+        if (path.endsWith('global.json')) {
+          return JSON.stringify({ sdk: { version: '9.0.100' } });
+        }
+        if (path.endsWith('src/Web/Web.csproj')) {
+          return `
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net9.0</TargetFramework>
+                <UseMaui>true</UseMaui>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
+                <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.0" />
+                <PackageReference Include="xunit" Version="2.9.2" />
+                <PackageReference Include="NUnit" Version="4.2.2" />
+                <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+              </ItemGroup>
+            </Project>
+          `;
+        }
+        return '<Project />';
+      });
+
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return [];
+        if (path === '/test/project') {
+          return [
+            { name: 'MarketplaceDemo.slnx', isDirectory: () => false },
+            { name: 'global.json', isDirectory: () => false },
+            { name: 'Directory.Build.props', isDirectory: () => false },
+            { name: 'Directory.Packages.props', isDirectory: () => false },
+            { name: 'src', isDirectory: () => true },
+          ] as any;
+        }
+        if (path.endsWith('/src')) {
+          return [
+            { name: 'Web', isDirectory: () => true },
+          ] as any;
+        }
+        if (path.endsWith('/src/Web')) {
+          return ['Web.csproj'] as any;
+        }
+        return [];
+      });
+
+      const detector = new ProjectDetector('/test/project');
+      const stack = detector.analyze();
+
+      expect(stack.languages).toContainEqual(expect.objectContaining({ name: 'csharp' }));
+      expect(stack.runtime).toContainEqual(
+        expect.objectContaining({ name: 'dotnet', version: '9.0.100' })
+      );
+      expect(stack.frameworks).toContainEqual(expect.objectContaining({ name: 'aspnetcore' }));
+      expect(stack.frameworks).toContainEqual(expect.objectContaining({ name: 'blazor' }));
+      expect(stack.frameworks).toContainEqual(expect.objectContaining({ name: 'maui' }));
+      expect(stack.testing).toContainEqual(expect.objectContaining({ name: 'xunit' }));
+      expect(stack.testing).toContainEqual(expect.objectContaining({ name: 'nunit' }));
+      expect(stack.testing).toContainEqual(expect.objectContaining({ name: 'mstest' }));
+      expect(stack.tools).toContainEqual(expect.objectContaining({ name: 'msbuild' }));
+      expect(stack.tools).toContainEqual(expect.objectContaining({ name: 'nuget' }));
+    });
+
+    it('should detect F# project files without inferring C# from generic .NET SDK', () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return false;
+        return path.endsWith('Library.fsproj');
+      });
+
+      vi.mocked(readFileSync).mockReturnValue('<Project Sdk="Microsoft.NET.Sdk" />');
+      vi.mocked(readdirSync).mockReturnValue([
+        { name: 'Library.fsproj', isDirectory: () => false },
+      ] as any);
+
+      const detector = new ProjectDetector('/test/project');
+      const stack = detector.analyze();
+
+      expect(stack.languages).toContainEqual(expect.objectContaining({ name: 'fsharp' }));
+      expect(stack.languages).not.toContainEqual(expect.objectContaining({ name: 'csharp' }));
+    });
   });
 
   describe('framework detection', () => {

--- a/packages/core/src/context/__tests__/detector.test.ts
+++ b/packages/core/src/context/__tests__/detector.test.ts
@@ -262,6 +262,93 @@ describe('ProjectDetector', () => {
       expect(stack.languages).toContainEqual(expect.objectContaining({ name: 'fsharp' }));
       expect(stack.languages).not.toContainEqual(expect.objectContaining({ name: 'csharp' }));
     });
+
+    it('should not infer C# from F# solution files', () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return false;
+        return path.endsWith('App.slnx') || path.endsWith('Library.fsproj');
+      });
+
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return '';
+        if (path.endsWith('App.slnx')) {
+          return '<Project Path="src/Library/Library.fsproj" />';
+        }
+        return '<Project Sdk="Microsoft.NET.Sdk" />';
+      });
+
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return [];
+        if (path === '/test/project') {
+          return [
+            { name: 'App.slnx', isDirectory: () => false },
+            { name: 'src', isDirectory: () => true },
+          ] as any;
+        }
+        if (path.endsWith('/src')) {
+          return [
+            { name: 'Library', isDirectory: () => true },
+          ] as any;
+        }
+        if (path.endsWith('/src/Library')) {
+          return ['Library.fsproj'] as any;
+        }
+        return [];
+      });
+
+      const detector = new ProjectDetector('/test/project');
+      const stack = detector.analyze();
+
+      expect(stack.languages).toContainEqual(expect.objectContaining({ name: 'fsharp' }));
+      expect(stack.languages).not.toContainEqual(expect.objectContaining({ name: 'csharp' }));
+    });
+
+    it('should read nested global.json files for .NET SDK version', () => {
+      vi.mocked(existsSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return false;
+        return path.endsWith('global.json') || path.endsWith('App.csproj');
+      });
+
+      vi.mocked(readFileSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return '';
+        if (path.endsWith('samples/dotnet/global.json')) {
+          return JSON.stringify({ sdk: { version: '8.0.204' } });
+        }
+        return '<Project Sdk="Microsoft.NET.Sdk" />';
+      });
+
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        if (typeof path !== 'string') return [];
+        if (path === '/test/project') {
+          return [
+            { name: 'samples', isDirectory: () => true },
+          ] as any;
+        }
+        if (path.endsWith('/samples')) {
+          return [
+            { name: 'dotnet', isDirectory: () => true },
+          ] as any;
+        }
+        if (path.endsWith('/samples/dotnet')) {
+          return [
+            { name: 'global.json', isDirectory: () => false },
+            { name: 'App.csproj', isDirectory: () => false },
+          ] as any;
+        }
+        return [];
+      });
+
+      const detector = new ProjectDetector('/test/project');
+      const stack = detector.analyze();
+
+      expect(stack.runtime).toContainEqual(
+        expect.objectContaining({
+          name: 'dotnet',
+          version: '8.0.204',
+          source: 'samples/dotnet/global.json',
+        })
+      );
+    });
   });
 
   describe('framework detection', () => {

--- a/packages/core/src/context/detector.ts
+++ b/packages/core/src/context/detector.ts
@@ -806,13 +806,12 @@ export class ProjectDetector {
     }
 
     if (
-      this.hasDotNetFileWithExtension('.csproj') ||
-      this.hasDotNetSolution()
+      this.hasDotNetFileWithExtension('.csproj')
     ) {
       languages.push({
         name: 'csharp',
         confidence: 100,
-        source: this.firstDotNetFile('.csproj') || this.firstDotNetSolution(),
+        source: this.firstDotNetFile('.csproj'),
       });
     }
 
@@ -826,7 +825,7 @@ export class ProjectDetector {
       name: 'dotnet',
       version: this.getDotNetSdkVersion(),
       confidence: 100,
-      source: this.hasFile('global.json') ? 'global.json' : this.firstDotNetMarker(),
+      source: this.firstFileNamed('global.json') || this.firstDotNetMarker(),
     };
   }
 
@@ -953,15 +952,23 @@ export class ProjectDetector {
   }
 
   private getDotNetSdkVersion(): string | undefined {
-    if (!this.hasFile('global.json')) return undefined;
+    const globalJsonPath = this.firstFileNamed('global.json');
+    if (!globalJsonPath) return undefined;
 
     try {
-      const content = this.readProjectFile('global.json');
+      const content = this.readProjectFile(globalJsonPath);
       const data = JSON.parse(content) as { sdk?: { version?: unknown } };
       return typeof data.sdk?.version === 'string' ? data.sdk.version : undefined;
     } catch {
       return undefined;
     }
+  }
+
+  private firstFileNamed(name: string): string | undefined {
+    for (const file of this.files) {
+      if (basename(file) === name) return file;
+    }
+    return undefined;
   }
 
   private getDotNetText(): string {

--- a/packages/core/src/context/detector.ts
+++ b/packages/core/src/context/detector.ts
@@ -2,6 +2,28 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import type { ProjectStack, Detection, ProjectPatterns } from './types.js';
 
+const DOTNET_MARKER_FILES = [
+  'global.json',
+  'Directory.Build.props',
+  'Directory.Build.targets',
+  'Directory.Packages.props',
+  'NuGet.config',
+  'packages.config',
+];
+
+const DOTNET_PROJECT_EXTENSIONS = ['.csproj', '.fsproj', '.vbproj'];
+const DOTNET_SOLUTION_EXTENSIONS = ['.sln', '.slnx'];
+const SKIPPED_SCAN_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  'bin',
+  'obj',
+  '.next',
+  '.turbo',
+]);
+
 /**
  * Framework detection patterns
  */
@@ -419,12 +441,21 @@ export class ProjectDetector {
     // Detect everything
     const stack: ProjectStack = {
       languages: this.detectLanguages(),
-      frameworks: this.detectFromPatterns(FRAMEWORK_PATTERNS),
+      frameworks: this.mergeDetections(
+        this.detectFromPatterns(FRAMEWORK_PATTERNS),
+        this.detectDotNetFrameworks()
+      ),
       libraries: this.detectFromPatterns(LIBRARY_PATTERNS),
       styling: this.detectFromPatterns(STYLING_PATTERNS),
-      testing: this.detectFromPatterns(TESTING_PATTERNS),
+      testing: this.mergeDetections(
+        this.detectFromPatterns(TESTING_PATTERNS),
+        this.detectDotNetTesting()
+      ),
       databases: this.detectFromPatterns(DATABASE_PATTERNS),
-      tools: this.detectFromPatterns(TOOL_PATTERNS),
+      tools: this.mergeDetections(
+        this.detectFromPatterns(TOOL_PATTERNS),
+        this.detectDotNetTools()
+      ),
       runtime: this.detectRuntime(),
     };
 
@@ -538,24 +569,34 @@ export class ProjectDetector {
 
   private scanFiles(): void {
     try {
-      const entries = readdirSync(this.projectPath, { withFileTypes: true });
-      for (const entry of entries) {
-        this.files.add(entry.name);
-        if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
-          // Scan one level deep for common config locations
-          try {
-            const subEntries = readdirSync(join(this.projectPath, entry.name));
-            for (const subEntry of subEntries) {
-              this.files.add(`${entry.name}/${subEntry}`);
-            }
-          } catch {
-            // Ignore permission errors
-          }
-        }
-      }
+      this.scanDirectory('', 0, 2);
     } catch {
       // Ignore errors
     }
+  }
+
+  private scanDirectory(relativeDir: string, depth: number, maxDepth: number): void {
+    const dirPath = relativeDir ? join(this.projectPath, relativeDir) : this.projectPath;
+    const entries = readdirSync(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const name = typeof entry === 'string' ? entry : entry.name;
+      const relativePath = relativeDir ? `${relativeDir}/${name}` : name;
+      this.files.add(relativePath);
+
+      const isDirectory = typeof entry === 'string' ? false : entry.isDirectory();
+      if (isDirectory && depth < maxDepth && !this.shouldSkipDirectory(name)) {
+        try {
+          this.scanDirectory(relativePath, depth + 1, maxDepth);
+        } catch {
+          // Ignore permission errors
+        }
+      }
+    }
+  }
+
+  private shouldSkipDirectory(name: string): boolean {
+    return name.startsWith('.') || SKIPPED_SCAN_DIRS.has(name);
   }
 
   private getDependencies(): Set<string> {
@@ -655,6 +696,9 @@ export class ProjectDetector {
       });
     }
 
+    // DotNet
+    languages.push(...this.detectDotNetLanguages());
+
     return languages;
   }
 
@@ -689,6 +733,12 @@ export class ProjectDetector {
         confidence: 100,
         source: 'deno.json',
       });
+    }
+
+    // DotNet
+    const dotnetRuntime = this.detectDotNetRuntime();
+    if (dotnetRuntime) {
+      runtime.push(dotnetRuntime);
     }
 
     return runtime;
@@ -738,6 +788,219 @@ export class ProjectDetector {
     }
 
     return detected;
+  }
+
+  private detectDotNetLanguages(): Detection[] {
+    const languages: Detection[] = [];
+
+    if (this.hasDotNetFileWithExtension('.fsproj')) {
+      languages.push({ name: 'fsharp', confidence: 100, source: this.firstDotNetFile('.fsproj') });
+    }
+
+    if (this.hasDotNetFileWithExtension('.vbproj')) {
+      languages.push({
+        name: 'visual-basic',
+        confidence: 100,
+        source: this.firstDotNetFile('.vbproj'),
+      });
+    }
+
+    if (
+      this.hasDotNetFileWithExtension('.csproj') ||
+      this.hasDotNetSolution()
+    ) {
+      languages.push({
+        name: 'csharp',
+        confidence: 100,
+        source: this.firstDotNetFile('.csproj') || this.firstDotNetSolution(),
+      });
+    }
+
+    return languages;
+  }
+
+  private detectDotNetRuntime(): Detection | null {
+    if (!this.hasDotNetMarker()) return null;
+
+    return {
+      name: 'dotnet',
+      version: this.getDotNetSdkVersion(),
+      confidence: 100,
+      source: this.hasFile('global.json') ? 'global.json' : this.firstDotNetMarker(),
+    };
+  }
+
+  private detectDotNetFrameworks(): Detection[] {
+    const content = this.getDotNetText().toLowerCase();
+    const frameworks: Detection[] = [];
+
+    if (
+      content.includes('microsoft.net.sdk.web') ||
+      content.includes('microsoft.aspnetcore.') ||
+      content.includes('microsoft.aspnetcore"')
+    ) {
+      frameworks.push({ name: 'aspnetcore', confidence: 100, source: this.firstDotNetProjectFile() });
+    }
+
+    if (content.includes('microsoft.aspnetcore.components')) {
+      frameworks.push({ name: 'blazor', confidence: 100, source: this.firstDotNetProjectFile() });
+    }
+
+    if (
+      content.includes('<usemaui>true</usemaui>') ||
+      content.includes('microsoft.maui.') ||
+      content.includes('microsoft.net.sdk.maui')
+    ) {
+      frameworks.push({ name: 'maui', confidence: 100, source: this.firstDotNetProjectFile() });
+    }
+
+    return frameworks;
+  }
+
+  private detectDotNetTesting(): Detection[] {
+    const content = this.getDotNetText();
+    const lowerContent = content.toLowerCase();
+    const testing: Detection[] = [];
+    const source = this.firstDotNetProjectFile();
+
+    if (lowerContent.includes('xunit')) {
+      testing.push({ name: 'xunit', confidence: 100, source });
+    }
+    if (content.includes('NUnit')) {
+      testing.push({ name: 'nunit', confidence: 100, source });
+    }
+    if (content.includes('MSTest')) {
+      testing.push({ name: 'mstest', confidence: 100, source });
+    }
+
+    return testing;
+  }
+
+  private detectDotNetTools(): Detection[] {
+    const tools: Detection[] = [];
+    const content = this.getDotNetText();
+
+    if (
+      this.hasDotNetSolution() ||
+      this.hasDotNetProjectFile() ||
+      this.hasFile('Directory.Build.props') ||
+      this.hasFile('Directory.Build.targets')
+    ) {
+      tools.push({ name: 'msbuild', confidence: 100, source: this.firstDotNetMarker() });
+    }
+
+    if (
+      this.hasFile('NuGet.config') ||
+      this.hasFile('packages.config') ||
+      this.hasFile('Directory.Packages.props') ||
+      content.includes('PackageReference')
+    ) {
+      tools.push({ name: 'nuget', confidence: 100, source: this.firstDotNetMarker() });
+    }
+
+    return tools;
+  }
+
+  private hasDotNetMarker(): boolean {
+    return (
+      DOTNET_MARKER_FILES.some((file) => this.hasFile(file)) ||
+      this.hasDotNetSolution() ||
+      this.hasDotNetProjectFile()
+    );
+  }
+
+  private firstDotNetMarker(): string | undefined {
+    return (
+      this.firstDotNetSolution() ||
+      this.firstDotNetProjectFile() ||
+      DOTNET_MARKER_FILES.find((file) => this.hasFile(file))
+    );
+  }
+
+  private hasDotNetSolution(): boolean {
+    return DOTNET_SOLUTION_EXTENSIONS.some((extension) => this.hasDotNetFileWithExtension(extension));
+  }
+
+  private firstDotNetSolution(): string | undefined {
+    for (const extension of DOTNET_SOLUTION_EXTENSIONS) {
+      const file = this.firstDotNetFile(extension);
+      if (file) return file;
+    }
+    return undefined;
+  }
+
+  private hasDotNetProjectFile(): boolean {
+    return DOTNET_PROJECT_EXTENSIONS.some((extension) => this.hasDotNetFileWithExtension(extension));
+  }
+
+  private firstDotNetProjectFile(): string | undefined {
+    for (const extension of DOTNET_PROJECT_EXTENSIONS) {
+      const file = this.firstDotNetFile(extension);
+      if (file) return file;
+    }
+    return undefined;
+  }
+
+  private hasDotNetFileWithExtension(extension: string): boolean {
+    return this.firstDotNetFile(extension) !== undefined;
+  }
+
+  private firstDotNetFile(extension: string): string | undefined {
+    for (const file of this.files) {
+      if (file.endsWith(extension)) return file;
+    }
+    return undefined;
+  }
+
+  private getDotNetSdkVersion(): string | undefined {
+    if (!this.hasFile('global.json')) return undefined;
+
+    try {
+      const content = this.readProjectFile('global.json');
+      const data = JSON.parse(content) as { sdk?: { version?: unknown } };
+      return typeof data.sdk?.version === 'string' ? data.sdk.version : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private getDotNetText(): string {
+    const parts: string[] = [];
+    const dotnetFiles = Array.from(this.files).filter((file) => (
+      DOTNET_PROJECT_EXTENSIONS.some((extension) => file.endsWith(extension)) ||
+      file.endsWith('.props') ||
+      file.endsWith('.targets') ||
+      file.endsWith('packages.config') ||
+      file.endsWith('NuGet.config')
+    ));
+
+    for (const file of dotnetFiles) {
+      try {
+        parts.push(this.readProjectFile(file));
+      } catch {
+        // Ignore unreadable project files
+      }
+    }
+
+    return parts.join('\n');
+  }
+
+  private readProjectFile(relativePath: string): string {
+    return readFileSync(join(this.projectPath, relativePath), 'utf-8');
+  }
+
+  private mergeDetections(primary: Detection[], extra: Detection[]): Detection[] {
+    const merged = [...primary];
+    const seen = new Set(primary.map((detection) => detection.name));
+
+    for (const detection of extra) {
+      if (!seen.has(detection.name)) {
+        merged.push(detection);
+        seen.add(detection.name);
+      }
+    }
+
+    return merged;
   }
 }
 

--- a/packages/core/src/recommend/__tests__/engine.test.ts
+++ b/packages/core/src/recommend/__tests__/engine.test.ts
@@ -232,6 +232,67 @@ describe('RecommendationEngine', () => {
   });
 
   describe('recommend', () => {
+    it('should rank .NET matching skills above unrelated skills', () => {
+      const dotnetProfile: ProjectProfile = {
+        name: 'dotnet-web',
+        type: 'web-app',
+        stack: {
+          languages: [{ name: 'csharp', confidence: 100 }],
+          frameworks: [{ name: 'aspnetcore', confidence: 100 }],
+          libraries: [],
+          styling: [],
+          testing: [{ name: 'xunit', confidence: 100 }],
+          databases: [],
+          tools: [{ name: 'msbuild', confidence: 100 }, { name: 'nuget', confidence: 100 }],
+          runtime: [{ name: 'dotnet', version: '9.0.100', confidence: 100 }],
+        },
+        installedSkills: [],
+        excludedSkills: [],
+      };
+
+      const dotnetIndex: SkillIndex = {
+        version: 1,
+        lastUpdated: new Date().toISOString(),
+        sources: [],
+        skills: [
+          {
+            name: 'dotnet-aspnetcore',
+            tags: ['dotnet', 'csharp', 'aspnetcore'],
+            compatibility: {
+              languages: ['csharp'],
+              frameworks: ['aspnetcore'],
+              libraries: [],
+            },
+            quality: 90,
+            popularity: 250,
+            lastUpdated: new Date().toISOString(),
+          },
+          {
+            name: 'python-fastapi',
+            tags: ['python', 'fastapi'],
+            compatibility: {
+              languages: ['python'],
+              frameworks: ['fastapi'],
+              libraries: [],
+            },
+            quality: 90,
+            popularity: 250,
+            lastUpdated: new Date().toISOString(),
+          },
+        ],
+      };
+
+      engine.loadIndex(dotnetIndex);
+
+      const result = engine.recommend(dotnetProfile, {
+        limit: 2,
+        minScore: 0,
+      });
+
+      expect(result.recommendations[0].skill.name).toBe('dotnet-aspnetcore');
+      expect(result.recommendations[0].score).toBeGreaterThan(result.recommendations[1].score);
+    });
+
     it('should return recommendations sorted by score', () => {
       const result = engine.recommend(sampleProfile);
 

--- a/packages/core/src/recommend/fetcher.ts
+++ b/packages/core/src/recommend/fetcher.ts
@@ -9,7 +9,7 @@ import {
 import { join, dirname } from "node:path";
 import { tmpdir, homedir } from "node:os";
 import { randomUUID } from "node:crypto";
-import type { SkillIndex, SkillSummary, IndexSource } from "./types.js";
+import type { SkillIndex, SkillSummary, IndexSource, SkillRepoSource } from "./types.js";
 import { discoverSkills, extractFrontmatter } from "../skills.js";
 
 /**
@@ -31,7 +31,7 @@ export const KNOWN_SKILL_REPOS = [
     repo: "awesome-claude-skills",
     description: "Curated Claude Code skills",
   },
-] as const;
+] as const satisfies readonly SkillRepoSource[];
 
 /**
  * Index file path
@@ -130,7 +130,7 @@ export async function fetchSkillsFromRepo(
  * Fetch skills from all known repositories and build index
  */
 export async function buildSkillIndex(
-  repos: typeof KNOWN_SKILL_REPOS = KNOWN_SKILL_REPOS,
+  repos: readonly SkillRepoSource[] = KNOWN_SKILL_REPOS,
   onProgress?: (message: string) => void,
 ): Promise<{ index: SkillIndex; errors: string[] }> {
   const allSkills: SkillSummary[] = [];

--- a/packages/core/src/recommend/types.ts
+++ b/packages/core/src/recommend/types.ts
@@ -109,6 +109,15 @@ export interface SkillIndex {
 }
 
 /**
+ * GitHub repository source used to build the recommendation index
+ */
+export interface SkillRepoSource {
+  owner: string;
+  repo: string;
+  description?: string;
+}
+
+/**
  * Source repository in the index
  */
 export interface IndexSource {


### PR DESCRIPTION
 ## Summary
  - Add lightweight .NET project detection for solutions, project files, SDK/global.json, ASP.NET Core, Blazor, MAUI, test frameworks, MSBuild, and NuGet.
  - Include custom taps in `skillkit recommend --update`.
  - Add focused tests and docs for recommendation behavior.

 ## Validation
  - pnpm test
  - pnpm lint
  - pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting .NET projects and recommendations signals, including ASP.NET Core, Blazor, MAUI, common test frameworks, and related build tooling.
  * Improved `skillkit recommend --update` to refresh the recommendation index from built-in sources plus configured GitHub taps, with automatic deduplication.
* **Bug Fixes**
  * Invalid tap entries are now reported as warnings (and skipped) without failing the update.
* **Documentation**
  * Expanded documentation for project context detection with .NET markers and signals.
  * Documented the `skillkit recommend --update` behavior and refresh expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->