### PR TITLE
docs: add Hermes Tweet skill registry entry

### DIFF
--- a/registry/SKILLS.md
+++ b/registry/SKILLS.md
@@ -45,6 +45,10 @@ A curated list of community-contributed skills for AI coding agents.
 - [api-docs](https://github.com/anthropics/skills) - API documentation generation
 - [readme-guide](https://github.com/anthropics/skills) - README writing best practices
 
+## Social & Publishing
+
+- [hermes-tweet](https://github.com/Xquik-dev/hermes-tweet) - X/Twitter search, account reads, and guarded posting for Hermes Agent
+
 ## AI & ML
 
 - [prompt-engineering](https://github.com/anthropics/skills) - Prompt engineering patterns


### PR DESCRIPTION
## Summary

Adds hermes-tweet to the SkillKit community registry under Social & Publishing.

## Validation

- Target repo is non-archived and Apache-2.0 licensed; Hermes Tweet remains under its own MIT license.
- Checked the SkillKit README, contribution docs, registry docs, open and closed PRs/issues, and code search for existing Hermes Tweet or hermes-tweet entries. None were present.
- Confirmed Hermes Tweet exposes a public skills/hermes-tweet/SKILL.md and ran the current Hermes Agent compatibility gate successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Social & Publishing" section to the skills registry, providing better categorization for social and publishing-related skills
  * Reorganized and relocated existing skill entries across multiple sections to enhance overall registry structure and improve discoverability of skills

<!-- end of auto-generated comment: release notes by coderabbit.ai -->