### PR TITLE
feat: add Hermes Tweet marketplace skill

### DIFF
--- a/marketplace/skills.json
+++ b/marketplace/skills.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./schema.json",
   "version": 1,
-  "updatedAt": "2026-02-28",
-  "totalSkills": 15120,
+  "updatedAt": "2026-06-22",
+  "totalSkills": 15121,
   "curatedCollections": 33,
   "skills": [
     {
@@ -126269,6 +126269,19 @@
         "multi-agent",
         "startup",
         "autonomous"
+      ]
+    },
+    {
+      "id": "Xquik-dev/hermes-tweet/hermes-tweet",
+      "name": "Hermes Tweet",
+      "description": "Hermes Agent X/Twitter plugin for read-first social monitoring and approval-gated account actions through Xquik.",
+      "source": "Xquik-dev/hermes-tweet",
+      "tags": [
+        "hermes-agent",
+        "twitter",
+        "x",
+        "social-media",
+        "automation"
       ]
     }
   ]

--- a/marketplace/skills.json
+++ b/marketplace/skills.json
@@ -126275,6 +126275,7 @@
       "id": "Xquik-dev/hermes-tweet/hermes-tweet",
       "name": "Hermes Tweet",
       "description": "Hermes Agent X/Twitter plugin for read-first social monitoring and approval-gated account actions through Xquik.",
+      "path": "skills/hermes-tweet/SKILL.md",
       "source": "Xquik-dev/hermes-tweet",
       "tags": [
         "hermes-agent",

--- a/marketplace/sources.json
+++ b/marketplace/sources.json
@@ -37,6 +37,7 @@
     { "source": "intellectronica/agent-skills", "name": "Context7" },
     { "source": "muratcankoylan/Agent-Skills-for-Context-Engineering", "name": "Context Engineering" },
     { "source": "sickn33/antigravity-awesome-skills", "name": "Antigravity Awesome Skills" },
+    { "source": "Xquik-dev/hermes-tweet", "name": "Hermes Tweet" },
     { "source": "NousResearch/hermes-agent", "name": "Hermes Agent Skills" },
     { "source": "skills.sh", "name": "Skills.sh Leaderboard", "official": true, "registry": "skills-sh" }
   ]


### PR DESCRIPTION
## Summary
- add Xquik-dev/hermes-tweet as a curated SkillKit source
- add the Hermes Tweet marketplace entry for the native skills/hermes-tweet/SKILL.md package
- tag it for Hermes Agent, X/Twitter, social media, and automation discovery without setting unsupported agent metadata

## Validation
- parsed marketplace/skills.json and marketplace/sources.json with Node
- verified totalSkills matches the skills array length
- verified the Hermes Tweet skill/source entries are unique and match the marketplace patterns
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Hermes Tweet** skill to the marketplace, providing an X/Twitter plugin for read-first social monitoring and approval-gated automation actions.
* **Marketplace Updates**
  * Added the corresponding **Hermes Tweet** source entry and refreshed marketplace metadata (including updated timestamps and totals).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->