### PR TITLE
feat(ai): add MiniMax provider to the AI provider factory

### DIFF
--- a/packages/cli/src/commands/ai.ts
+++ b/packages/cli/src/commands/ai.ts
@@ -429,9 +429,11 @@ export class AICommand extends Command {
           ? ('google' as const)
           : process.env.OPENROUTER_API_KEY
             ? ('openrouter' as const)
-            : process.env.OLLAMA_HOST
-              ? ('ollama' as const)
-              : ('none' as const);
+            : process.env.MINIMAX_API_KEY
+              ? ('minimax' as const)
+              : process.env.OLLAMA_HOST
+                ? ('ollama' as const)
+                : ('none' as const);
 
     const apiKey =
       provider === 'anthropic'
@@ -442,7 +444,9 @@ export class AICommand extends Command {
             ? (process.env.GOOGLE_AI_KEY || process.env.GEMINI_API_KEY)
             : provider === 'openrouter'
               ? process.env.OPENROUTER_API_KEY
-              : undefined;
+              : provider === 'minimax'
+                ? process.env.MINIMAX_API_KEY
+                : undefined;
 
     return {
       provider,

--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -48,7 +48,7 @@ export class EvalCommand extends Command {
   });
 
   provider = Option.String('--provider,-p', {
-    description: 'LLM provider: anthropic, openai, google, ollama, openrouter',
+    description: 'LLM provider: anthropic, openai, google, ollama, openrouter, minimax',
   });
 
   model = Option.String('--model,-m', {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -27,7 +27,7 @@ export class GenerateCommand extends Command {
       - Marketplace skills (400K+)
       - Memory observations and learnings
 
-      Supports multiple LLM providers: Claude, GPT-4, Gemini, Ollama, OpenRouter
+      Supports multiple LLM providers: Claude, GPT-4, Gemini, Ollama, OpenRouter, MiniMax
     `,
     examples: [
       ['Interactive wizard', '$0 generate'],
@@ -39,7 +39,7 @@ export class GenerateCommand extends Command {
   });
 
   provider = Option.String('--provider,-p', {
-    description: 'LLM provider: anthropic, openai, google, ollama, openrouter',
+    description: 'LLM provider: anthropic, openai, google, ollama, openrouter, minimax',
   });
 
   model = Option.String('--model,-m', {
@@ -140,6 +140,7 @@ export class GenerateCommand extends Command {
   OPENAI_API_KEY - GPT-4 (OpenAI)
   GOOGLE_AI_KEY - Gemini (Google)
   OPENROUTER_API_KEY - OpenRouter (100+ models)
+  MINIMAX_API_KEY - MiniMax (global or CN endpoint)
 
 Or use Ollama for local models (no API key needed)`,
         'Provider Setup'

--- a/packages/core/src/ai/providers/__tests__/minimax.test.ts
+++ b/packages/core/src/ai/providers/__tests__/minimax.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { MiniMaxProvider } from '../minimax.js';
+import {
+  createProvider,
+  detectProviders,
+  getDefaultProvider,
+  getProviderEnvVars,
+  getProviderModels,
+  isProviderConfigured,
+} from '../factory.js';
+import type { ChatMessage } from '../types.js';
+
+const ENVS = ['MINIMAX_API_KEY', 'MINIMAX_BASE_URL', 'MINIMAX_REGION', 'OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_AI_KEY', 'GEMINI_API_KEY', 'OLLAMA_HOST'];
+
+const restoreEnv = (): void => {
+  for (const key of ENVS) {
+    if (!(key in process.env)) continue;
+    delete process.env[key];
+  }
+};
+
+afterEach(() => {
+  restoreEnv();
+  vi.restoreAllMocks();
+});
+
+describe('MiniMaxProvider', () => {
+  it('is configured when MINIMAX_API_KEY is set', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    const provider = new MiniMaxProvider();
+    expect(provider.isConfigured()).toBe(true);
+    expect(provider.name).toBe('minimax');
+    expect(provider.displayName).toBe('MiniMax');
+  });
+
+  it('is not configured without an API key', () => {
+    const provider = new MiniMaxProvider();
+    expect(provider.isConfigured()).toBe(false);
+  });
+
+  it('defaults to the global base URL and MiniMax-M3 model', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    const provider = new MiniMaxProvider();
+    expect(provider['model']).toBe('MiniMax-M3');
+    expect(provider['baseUrl']).toBe('https://api.minimax.io/v1');
+  });
+
+  it('selects the CN base URL when MINIMAX_REGION is cn', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    process.env.MINIMAX_REGION = 'cn';
+    const provider = new MiniMaxProvider();
+    expect(provider['baseUrl']).toBe('https://api.minimaxi.com/v1');
+  });
+
+  it('honours an explicit config baseUrl over region defaults', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    process.env.MINIMAX_REGION = 'cn';
+    const provider = new MiniMaxProvider({ baseUrl: 'https://custom.example.com/v1/' });
+    expect(provider['baseUrl']).toBe('https://custom.example.com/v1');
+  });
+
+  it('honours MINIMAX_BASE_URL over region defaults', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    process.env.MINIMAX_REGION = 'cn';
+    process.env.MINIMAX_BASE_URL = 'https://env.example.com/v1/';
+    const provider = new MiniMaxProvider();
+    expect(provider['baseUrl']).toBe('https://env.example.com/v1');
+  });
+
+  it('sends an OpenAI-compatible chat completion request and returns content', async () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    const provider = new MiniMaxProvider({ model: 'MiniMax-M2.7' });
+
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const messages: ChatMessage[] = [{ role: 'user', content: 'hi' }];
+    const result = await provider.chat(messages);
+
+    expect(result).toBe('hello');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('https://api.minimax.io/v1/chat/completions');
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.model).toBe('MiniMax-M2.7');
+    expect(body.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer test-key',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('throws a clear error when not configured', async () => {
+    const provider = new MiniMaxProvider();
+    await expect(provider.chat([{ role: 'user', content: 'hi' }])).rejects.toThrow(
+      'MiniMax API key not configured',
+    );
+  });
+
+  it('surfaces non-2xx responses as an API error', async () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    const provider = new MiniMaxProvider();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('bad request', { status: 400 })),
+    );
+
+    await expect(provider.chat([{ role: 'user', content: 'hi' }])).rejects.toThrow(
+      'MiniMax API error: 400',
+    );
+  });
+});
+
+describe('MiniMax factory integration', () => {
+  it('detects MiniMax when MINIMAX_API_KEY is set', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    const detected = detectProviders();
+    const minimax = detected.find((d) => d.provider === 'minimax');
+    expect(minimax).toBeDefined();
+    expect(minimax?.configured).toBe(true);
+    expect(minimax?.envVar).toBe('MINIMAX_API_KEY');
+  });
+
+  it('selects MiniMax as the default provider when only MINIMAX_API_KEY is set', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    expect(getDefaultProvider()).toBe('minimax');
+  });
+
+  it('creates a MiniMaxProvider via createProvider', () => {
+    process.env.MINIMAX_API_KEY = 'test-key';
+    const provider = createProvider('minimax');
+    expect(provider.name).toBe('minimax');
+    expect(provider.isConfigured()).toBe(true);
+  });
+
+  it('reports configuration status for MiniMax', () => {
+    expect(isProviderConfigured('minimax')).toBe(false);
+    process.env.MINIMAX_API_KEY = 'test-key';
+    expect(isProviderConfigured('minimax')).toBe(true);
+  });
+
+  it('exposes MiniMax env vars and models', () => {
+    expect(getProviderEnvVars().minimax).toEqual(['MINIMAX_API_KEY']);
+    expect(getProviderModels('minimax')).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
+  });
+});

--- a/packages/core/src/ai/providers/factory.ts
+++ b/packages/core/src/ai/providers/factory.ts
@@ -4,6 +4,7 @@ import { OpenAIProvider } from './openai.js';
 import { GoogleProvider } from './google.js';
 import { OllamaProvider } from './ollama.js';
 import { OpenRouterProvider } from './openrouter.js';
+import { MiniMaxProvider } from './minimax.js';
 import { MockAIProvider } from './mock.js';
 
 export interface ProviderDetectionResult {
@@ -52,6 +53,15 @@ export function detectProviders(): ProviderDetectionResult[] {
     });
   }
 
+  if (process.env.MINIMAX_API_KEY) {
+    results.push({
+      provider: 'minimax',
+      displayName: 'MiniMax',
+      configured: true,
+      envVar: 'MINIMAX_API_KEY',
+    });
+  }
+
   results.push({
     provider: 'ollama',
     displayName: 'Ollama (Local)',
@@ -67,6 +77,7 @@ export function getDefaultProvider(): ProviderName {
   if (process.env.OPENAI_API_KEY) return 'openai';
   if (process.env.GOOGLE_AI_KEY || process.env.GEMINI_API_KEY) return 'google';
   if (process.env.OPENROUTER_API_KEY) return 'openrouter';
+  if (process.env.MINIMAX_API_KEY) return 'minimax';
   if (process.env.OLLAMA_HOST) return 'ollama';
 
   return 'mock';
@@ -94,6 +105,9 @@ export function createProvider(
     case 'openrouter':
       return new OpenRouterProvider(config);
 
+    case 'minimax':
+      return new MiniMaxProvider(config);
+
     case 'mock':
     default:
       return new MockAIProvider();
@@ -110,6 +124,8 @@ export function isProviderConfigured(providerName: ProviderName): boolean {
       return Boolean(process.env.GOOGLE_AI_KEY || process.env.GEMINI_API_KEY);
     case 'openrouter':
       return Boolean(process.env.OPENROUTER_API_KEY);
+    case 'minimax':
+      return Boolean(process.env.MINIMAX_API_KEY);
     case 'ollama':
       return true;
     case 'mock':
@@ -126,6 +142,7 @@ export function getProviderEnvVars(): Record<ProviderName, string[]> {
     google: ['GOOGLE_AI_KEY', 'GEMINI_API_KEY'],
     ollama: ['OLLAMA_HOST'],
     openrouter: ['OPENROUTER_API_KEY'],
+    minimax: ['MINIMAX_API_KEY'],
     mock: [],
   };
 }
@@ -148,6 +165,7 @@ export function getProviderModels(providerName: ProviderName): string[] {
       'meta-llama/llama-3.1-70b-instruct',
       'mistralai/mistral-large',
     ],
+    minimax: ['MiniMax-M3', 'MiniMax-M2.7'],
     mock: ['mock'],
   };
 

--- a/packages/core/src/ai/providers/index.ts
+++ b/packages/core/src/ai/providers/index.ts
@@ -5,6 +5,7 @@ export { OpenAIProvider } from './openai.js';
 export { GoogleProvider } from './google.js';
 export { OllamaProvider } from './ollama.js';
 export { OpenRouterProvider } from './openrouter.js';
+export { MiniMaxProvider } from './minimax.js';
 export {
   ProviderFactory,
   createProvider,

--- a/packages/core/src/ai/providers/minimax.ts
+++ b/packages/core/src/ai/providers/minimax.ts
@@ -1,0 +1,312 @@
+import type {
+  LLMProvider,
+  ProviderConfig,
+  GenerationContext,
+  GeneratedSkillResult,
+  WizardContext,
+  ClarificationQuestion,
+  SearchResult,
+  ChatMessage,
+} from './types.js';
+import type { SearchableSkill, GeneratedSkill, SkillExample } from '../types.js';
+
+interface MiniMaxMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface MiniMaxResponse {
+  choices: Array<{
+    message: { role: string; content: string };
+    finish_reason: string;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+}
+
+/**
+ * Selectable MiniMax OpenAI-compatible base URLs. The global endpoint serves the
+ * international API (`https://api.minimax.io/v1`), while the CN endpoint serves the
+ * China API (`https://api.minimaxi.com/v1`). Either is selected at construction time
+ * via `config.baseUrl`, the `MINIMAX_BASE_URL` env var (for a fully custom URL), or
+ * the `MINIMAX_REGION` env var.
+ */
+const MINIMAX_GLOBAL_BASE_URL = 'https://api.minimax.io/v1';
+const MINIMAX_CN_BASE_URL = 'https://api.minimaxi.com/v1';
+
+function resolveMiniMaxBaseUrl(configBaseUrl?: string): string {
+  if (configBaseUrl) return configBaseUrl.replace(/\/$/, '');
+  if (process.env.MINIMAX_BASE_URL) return process.env.MINIMAX_BASE_URL.replace(/\/$/, '');
+  const region = (process.env.MINIMAX_REGION || '').toLowerCase();
+  if (region === 'cn' || region === 'cn_zh' || region === 'china') {
+    return MINIMAX_CN_BASE_URL;
+  }
+  return MINIMAX_GLOBAL_BASE_URL;
+}
+
+/**
+ * MiniMax text provider.
+ *
+ * Reuses the existing OpenAI-compatible chat-completions request and response
+ * implementation, with MiniMax-specific defaults: the `MINIMAX_API_KEY` env var,
+ * the MiniMax-M3 default model, and selectable global/CN base URLs.
+ */
+export class MiniMaxProvider implements LLMProvider {
+  readonly name = 'minimax' as const;
+  readonly displayName = 'MiniMax';
+
+  private apiKey: string;
+  private model: string;
+  private maxTokens: number;
+  private temperature: number;
+  private baseUrl: string;
+
+  constructor(config: ProviderConfig = {}) {
+    this.apiKey = config.apiKey || process.env.MINIMAX_API_KEY || '';
+    this.model = config.model || 'MiniMax-M3';
+    this.maxTokens = config.maxTokens ?? 4096;
+    this.temperature = config.temperature ?? 0.7;
+    this.baseUrl = resolveMiniMaxBaseUrl(config.baseUrl);
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  async chat(messages: ChatMessage[]): Promise<string> {
+    if (!this.isConfigured()) {
+      throw new Error('MiniMax API key not configured');
+    }
+
+    const minimaxMessages: MiniMaxMessage[] = messages.map((m) => ({
+      role: m.role,
+      content: m.content,
+    }));
+
+    const response = await this.makeRequest(minimaxMessages);
+    const choice = response.choices[0];
+    if (!choice) {
+      throw new Error('MiniMax API returned no choices');
+    }
+    return choice.message.content || '';
+  }
+
+  async generateSkill(context: GenerationContext): Promise<GeneratedSkillResult> {
+    const systemPrompt = this.buildGenerationSystemPrompt();
+    const userPrompt = this.buildGenerationUserPrompt(context);
+
+    const response = await this.chat([
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ]);
+
+    return this.parseGeneratedSkillResult(response, context);
+  }
+
+  async generateClarifications(context: WizardContext): Promise<ClarificationQuestion[]> {
+    const systemPrompt = `You are an expert skill designer. Generate 2-4 clarification questions to help create a better skill.
+
+Return JSON array:
+[
+  {
+    "id": "q1",
+    "question": "Question text?",
+    "type": "select" | "text" | "confirm" | "multiselect",
+    "options": ["opt1", "opt2"] (for select/multiselect),
+    "context": "Why this matters"
+  }
+]`;
+
+    const contextSummary = context.gatheredContext
+      ?.map((c) => `[${c.source}] ${c.content.slice(0, 200)}...`)
+      .join('\n\n') || 'No context yet';
+
+    const userPrompt = `Expertise: ${context.expertise}
+Context: ${contextSummary}
+Agents: ${context.targetAgents.join(', ') || 'Not specified'}
+
+Generate questions:`;
+
+    const response = await this.chat([
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ]);
+
+    return this.parseJSON<ClarificationQuestion[]>(response, []);
+  }
+
+  async optimizeForAgent(skillContent: string, agentId: string): Promise<string> {
+    const constraints = this.getAgentConstraints(agentId);
+
+    const systemPrompt = `Optimize this skill for ${agentId}. Preserve core functionality while adapting to agent constraints. Return ONLY the optimized content.`;
+
+    const userPrompt = `Agent: ${agentId}
+Constraints: ${JSON.stringify(constraints)}
+
+Skill:
+${skillContent}`;
+
+    return this.chat([
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ]);
+  }
+
+  async search(query: string, skills: SearchableSkill[]): Promise<SearchResult[]> {
+    if (skills.length === 0) return [];
+
+    const skillsList = skills
+      .map((s, i) => `${i + 1}. ${s.name}${s.description ? ` - ${s.description}` : ''}`)
+      .join('\n');
+
+    const prompt = `Find relevant skills for: "${query}"\n\nSkills:\n${skillsList}\n\nReturn JSON array: [{"index": N, "relevance": 0-1, "reasoning": "why"}]`;
+    const response = await this.chat([{ role: 'user', content: prompt }]);
+
+    try {
+      const match = response.match(/\[[\s\S]*\]/);
+      if (match) {
+        const parsed = JSON.parse(match[0]) as Array<{ index: number; relevance: number; reasoning: string }>;
+        return parsed
+          .filter((item) => Number.isInteger(item.index) && item.index >= 1 && item.index <= skills.length)
+          .map((item) => ({
+            skill: skills[item.index - 1],
+            relevance: item.relevance,
+            reasoning: item.reasoning,
+          }));
+      }
+    } catch {
+      // Parse error
+    }
+    return [];
+  }
+
+  async generateFromExample(example: SkillExample): Promise<GeneratedSkill> {
+    let prompt = `Generate a skill for: ${example.description}`;
+    if (example.context) prompt += `\nContext: ${example.context}`;
+    prompt += `\n\nReturn JSON: {"name": "...", "description": "...", "content": "...", "tags": [], "confidence": 0-1, "reasoning": "..."}`;
+
+    const response = await this.chat([{ role: 'user', content: prompt }]);
+
+    try {
+      const match = response.match(/\{[\s\S]*\}/);
+      if (match) {
+        const parsed = JSON.parse(match[0]);
+        if (typeof parsed.name !== 'string' || typeof parsed.description !== 'string' || typeof parsed.content !== 'string') {
+          throw new Error('Missing required fields: name, description, content');
+        }
+        return {
+          name: parsed.name,
+          description: parsed.description,
+          content: parsed.content,
+          tags: Array.isArray(parsed.tags) ? parsed.tags : [],
+          confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0.7,
+          reasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning : '',
+        };
+      }
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('required fields')) throw e;
+    }
+    throw new Error('Failed to parse skill generation response');
+  }
+
+  private async makeRequest(messages: MiniMaxMessage[]): Promise<MiniMaxResponse> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 120000);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.model,
+          messages,
+          max_tokens: this.maxTokens,
+          temperature: this.temperature,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const error = await response.text();
+        throw new Error(`MiniMax API error: ${response.status} - ${error}`);
+      }
+
+      return response.json() as Promise<MiniMaxResponse>;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private buildGenerationSystemPrompt(): string {
+    return `You are an expert AI skill designer. Create high-quality SKILL.md files.
+
+Output JSON:
+{
+  "name": "kebab-case-name",
+  "description": "One-line description",
+  "content": "Full SKILL.md markdown",
+  "tags": ["tag1", "tag2"],
+  "confidence": 0.0-1.0,
+  "reasoning": "Design rationale"
+}`;
+  }
+
+  private buildGenerationUserPrompt(context: GenerationContext): string {
+    let prompt = `Create skill: ${context.expertise}\n\n`;
+
+    if (context.contextChunks.length > 0) {
+      prompt += '## Context\n';
+      for (const chunk of context.contextChunks) {
+        prompt += `[${chunk.source}] ${chunk.content.slice(0, 500)}\n\n`;
+      }
+    }
+
+    if (context.clarifications.length > 0) {
+      prompt += '## Clarifications\n';
+      for (const c of context.clarifications) {
+        prompt += `- ${c.questionId}: ${c.answer}\n`;
+      }
+    }
+
+    if (context.targetAgents.length > 0) {
+      prompt += `\nTargets: ${context.targetAgents.join(', ')}\n`;
+    }
+
+    return prompt;
+  }
+
+  private parseGeneratedSkillResult(response: string, context: GenerationContext): GeneratedSkillResult {
+    const parsed = this.parseJSON<GeneratedSkill>(response, {
+      name: 'generated-skill',
+      description: 'AI-generated skill',
+      content: response,
+      tags: [],
+      confidence: 0.5,
+      reasoning: '',
+    });
+
+    return { ...parsed, composedFrom: context.composedFrom };
+  }
+
+  private parseJSON<T>(response: string, defaultValue: T): T {
+    try {
+      const match = response.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
+      if (match) return JSON.parse(match[0]) as T;
+      return defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  }
+
+  private getAgentConstraints(agentId: string): Record<string, unknown> {
+    const constraints: Record<string, Record<string, unknown>> = {
+      'claude-code': { maxContext: 200000, markdown: true, mcp: true },
+      cursor: { maxContext: 32000, markdown: true, mcp: false },
+      codex: { maxContext: 8000, markdown: true, mcp: false },
+      universal: { maxContext: 8000, markdown: true, mcp: false },
+    };
+    return constraints[agentId] || constraints.universal;
+  }
+}

--- a/packages/core/src/ai/providers/types.ts
+++ b/packages/core/src/ai/providers/types.ts
@@ -1,6 +1,6 @@
 import type { SearchableSkill, GeneratedSkill, SkillExample } from '../types.js';
 
-export type ProviderName = 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'mock';
+export type ProviderName = 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'minimax' | 'mock';
 
 export interface ProviderConfig {
   apiKey?: string;

--- a/packages/core/src/ai/types.ts
+++ b/packages/core/src/ai/types.ts
@@ -36,7 +36,7 @@ export interface GeneratedSkill {
 }
 
 export interface AIConfig {
-  provider: 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'mock' | 'none';
+  provider: 'anthropic' | 'openai' | 'google' | 'ollama' | 'openrouter' | 'minimax' | 'mock' | 'none';
   apiKey?: string;
   model?: string;
   maxTokens?: number;


### PR DESCRIPTION
Reason: provider-add — add the MiniMax AI provider to the executable AI provider factory.

## Changes
- Add `MiniMaxProvider` (`packages/core/src/ai/providers/minimax.ts`), reusing the existing OpenAI-compatible chat-completion request and response implementation with provider-specific defaults: `MINIMAX_API_KEY` detection, the `MiniMax-M3` default model, and selectable global (`https://api.minimax.io/v1`) and CN (`https://api.minimaxi.com/v1`) base URLs via `MINIMAX_REGION` or `MINIMAX_BASE_URL`.
- Register MiniMax in the provider factory: detection in `detectProviders`, default selection in `getDefaultProvider`, the `createProvider` switch, `isProviderConfigured`, `getProviderEnvVars`, and `getProviderModels` (exposes `MiniMax-M3` and `MiniMax-M2.7`).
- Add `minimax` to the `ProviderName` and `AIConfig` provider unions and export `MiniMaxProvider` from the providers index.
- Wire the new provider into the CLI: provider selection setup note (`generate`), `--provider` help text (`eval`), and `getAIConfig` env-var detection (`ai`).
- Add `packages/core/src/ai/providers/__tests__/minimax.test.ts` covering configuration detection, base URL selection (global/CN/explicit/env), the OpenAI-compatible request shape, error handling, and factory integration.

## Checks
- `tsc --noEmit -p packages/core/tsconfig.json` — passed.
- `vitest run --root packages/core` (full core suite, 58 files / 1065 tests) — passed, including the new MiniMax tests (14 tests).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rohitg00/skillkit/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported AI provider.
  * MiniMax supports global and China endpoints, configurable models, skill generation, search, optimization, and clarification workflows.
  * The CLI now recognizes MiniMax configuration through `MINIMAX_API_KEY` and offers it in provider selection options.

* **Tests**
  * Added coverage for MiniMax configuration, requests, provider selection, model defaults, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->